### PR TITLE
Add content view in content script

### DIFF
--- a/src/manifest.ts
+++ b/src/manifest.ts
@@ -28,8 +28,14 @@ const manifest: ManifestType = {
   devtools_page: "src/pages/devtools/index.html",
   web_accessible_resources: [
     {
-      resources: ["contentStyle.css", "icon-128.png", "icon-34.png"],
-      matches: [],
+      resources: [
+        "assets/jsx-runtime.*.js",
+        "src/pages/contentView/index.js",
+        "contentStyle.css",
+        "icon-128.png",
+        "icon-34.png",
+      ],
+      matches: ["*://*/*"],
     },
   ],
 };

--- a/src/pages/content/index.ts
+++ b/src/pages/content/index.ts
@@ -1,5 +1,38 @@
 try {
   console.log("content loaded");
+  injectContentViewScript();
 } catch (e) {
   console.error(e);
+}
+
+/**
+ * @description
+ * Chrome extensions don't support modules in content scripts.
+ * Bundling solves this problem, but not in the case of React, which is imported as JSX automatic conversion.
+ * So, I created a tag that brings the 'content view' from the 'content script', and implemented it by bypassing the tag in the form of inserting it into the html.
+ * If there is a better implementation (bundling option or other method, etc.), please suggest it.
+ */
+function injectContentViewScript() {
+  const script = createContentViewScript();
+  const target = getTargetElement();
+
+  target.insertBefore(script, target.lastChild);
+}
+
+function createContentViewScript(): HTMLScriptElement {
+  const script = document.createElement("script");
+  script.setAttribute("type", "module");
+  script.setAttribute(
+    "src",
+    chrome.runtime.getURL("src/pages/contentView/index.js")
+  );
+  return script;
+}
+
+function getTargetElement(): HTMLElement {
+  return (
+    document.head ||
+    document.getElementsByTagName("head")[0] ||
+    document.documentElement
+  );
 }

--- a/src/pages/contentView/app.tsx
+++ b/src/pages/contentView/app.tsx
@@ -1,0 +1,9 @@
+import { useEffect } from "react";
+
+export default function App() {
+  useEffect(() => {
+    console.log("content view loaded");
+  }, []);
+
+  return <div>content view</div>;
+}

--- a/src/pages/contentView/index.tsx
+++ b/src/pages/contentView/index.tsx
@@ -1,0 +1,7 @@
+import { createRoot } from "react-dom/client";
+import App from "@pages/contentView/app";
+
+const div = document.createElement("div");
+document.body.append(div);
+
+createRoot(div).render(<App />);

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
         devtools: resolve(pagesDir, "devtools", "index.html"),
         panel: resolve(pagesDir, "panel", "index.html"),
         content: resolve(pagesDir, "content", "index.ts"),
+        contentView: resolve(pagesDir, "contentView", "index.tsx"),
         background: resolve(pagesDir, "background", "index.ts"),
         popup: resolve(pagesDir, "popup", "index.html"),
         newtab: resolve(pagesDir, "newtab", "index.html"),


### PR DESCRIPTION
- https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/7

Chrome extensions don't support modules in content scripts.

Bundling solves this problem, but not in the case of React, which is imported as JSX automatic conversion.

So, I created a tag that brings the 'content view' from the 'content script', and implemented it by bypassing the tag in the form of inserting it into the html.

If there is a better implementation (bundling option or other method, etc.), please suggest it 😄 

<img width="188" alt="스크린샷 2022-06-26 오후 4 17 01" src="https://user-images.githubusercontent.com/53500778/175803791-5cfe60e5-6306-4699-8e65-685510d18be5.png">
<img width="236" alt="스크린샷 2022-06-26 오후 4 17 16" src="https://user-images.githubusercontent.com/53500778/175803793-ee703f5d-e0c3-4b1c-a73a-e1e9fdd833fb.png">
