### PR TITLE
fix: custom-dynamic-import now working for import with then

### DIFF
--- a/utils/plugins/custom-dynamic-import.ts
+++ b/utils/plugins/custom-dynamic-import.ts
@@ -5,12 +5,9 @@ export default function customDynamicImport(): PluginOption {
     name: "custom-dynamic-import",
     renderDynamicImport() {
       return {
-        left: `
-        {
-          const dynamicImport = (path) => import(path);
-          dynamicImport(
+        left: `() => import(
           `,
-        right: ")}",
+        right: ")",
       };
     },
   };


### PR DESCRIPTION
Fix for #72 

After more research, I've found that the costume Vite plugin `custom-dynamic-import` was the origin of the problem. it looks like sometime Vite adds `.then()` after `__vitePreload` 

This update will make sure the syntax will stay good even if Vite add `.then` at the end