### PR TITLE
Support Firefox webextension

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,13 @@
   },
   "scripts": {
     "build": "tsc --noEmit && vite build",
+    "build:firefox": "tsc --noEmit && cross-env __FIREFOX__=true vite build",
     "build:watch": "cross-env __DEV__=true vite build -w",
+    "build:firefox:watch": "cross-env __DEV__=true __FIREFOX__=true vite build -w",
     "build:hmr": "rollup --config utils/reload/rollup.config.ts",
     "wss": "node utils/reload/initReloadServer.js",
     "dev": "npm run build:hmr && (run-p wss build:watch)",
+    "dev:firefox": "npm run build:hmr && (run-p wss build:firefox:watch)",
     "test": "jest"
   },
   "type": "module",

--- a/utils/manifest-parser/index.ts
+++ b/utils/manifest-parser/index.ts
@@ -5,7 +5,30 @@ class ManifestParser {
   private constructor() {}
 
   static convertManifestToString(manifest: Manifest): string {
+    if (process.env.__FIREFOX__) {
+      manifest = this.convertToFirefoxCompatibleManifest(manifest);
+    }
     return JSON.stringify(manifest, null, 2);
+  }
+
+  static convertToFirefoxCompatibleManifest(manifest: Manifest) {
+    const manifestCopy = {
+      ...manifest,
+    } as { [key: string]: unknown };
+
+    manifestCopy.background = {
+      scripts: [manifest.background?.service_worker],
+      type: "module",
+    };
+    manifestCopy.options_ui = {
+      page: manifest.options_page,
+      browser_style: false,
+    };
+    manifestCopy.content_security_policy = {
+      extension_pages: "script-src 'self'; object-src 'self'",
+    };
+    delete manifestCopy.options_page;
+    return manifestCopy as Manifest;
   }
 }
 

--- a/utils/plugins/custom-dynamic-import.ts
+++ b/utils/plugins/custom-dynamic-import.ts
@@ -4,6 +4,16 @@ export default function customDynamicImport(): PluginOption {
   return {
     name: "custom-dynamic-import",
     renderDynamicImport() {
+      if (process.env.__FIREFOX__) {
+        return {
+          left: `
+        {
+          const dynamicImport = (path) => import(path);
+          dynamicImport(browser.runtime.getURL('./') + 
+          `,
+          right: ".split('../').join(''))}",
+        };
+      }
       return {
         left: `
         {


### PR DESCRIPTION
closes #18

It looks like Firefox doesn't support adoptedStyleSheets in the content-script, even using not Shadow DOM, but even Document (probably related to this [bug](https://bugzilla.mozilla.org/show_bug.cgi?id=1770592)). 

So, regretfully, tailwind should come old way (linking to extension contentStyle) to make it work in FF content script.

IDK is it worth to create workaround to convert and inject twind styles into App.