### PR TITLE
Fix peer dependency issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "sass": "1.62.1",
     "ts-jest": "29.0.2",
     "ts-loader": "9.4.2",
-    "typescript": "4.8.3",
+    "typescript": "4.8.4",
     "vite": "3.1.3",
     "ws": "8.13.0"
   }


### PR DESCRIPTION
This PR is to fix a minor dependency version issue. Tested on Mac M1 with node 18 and 20, when I run `npm install`, I got the following error:

```
chrome-extension-boilerplate-react-vite$ node -v
v18.12.0
chrome-extension-boilerplate-react-vite$ npm -v
8.19.2
chrome-extension-boilerplate-react-vite$ npm install
npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: chrome-extension-boilerplate-react-vite@0.0.1
npm ERR! Found: typescript@4.8.3
npm ERR! node_modules/typescript
npm ERR!   dev typescript@"4.8.3" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peerOptional typescript@"^4.8.4" from @twind/preset-autoprefix@1.0.7
npm ERR! node_modules/@twind/preset-autoprefix
npm ERR!   dev @twind/preset-autoprefix@"^1.0.7" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force, or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
npm ERR! See /Users/mzou/.npm/eresolve-report.txt for a full report.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/mzou/.npm/_logs/2023-08-25T13_01_38_592Z-debug-0.log
```

Bumped TypeScript version to fix this issue.