### PR TITLE
fix/chrome api reference

### DIFF
--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,9 +1,3 @@
-import Chrome from 'chrome';
-
-declare namespace chrome {
-  export default Chrome;
-}
-
 declare module 'virtual:reload-on-update-in-background-script' {
   export const reloadOnUpdate: (watchPath: string) => void;
   export default reloadOnUpdate;


### PR DESCRIPTION
i was remove this namespace, cause it's don't give proper reference to chrome api.

And for react, reference to the chrome api is globally, this nemaspace is not necessary