### PR TITLE
[Enhance] modify to detect and reload manifest changes

### DIFF
--- a/manifest.js
+++ b/manifest.js
@@ -1,9 +1,10 @@
-import packageJson from './package.json';
+import packageJson from './package.json' assert { type: 'json' };
 
 /**
  * After changing, please reload the extension at `chrome://extensions`
+ * @type {chrome.runtime.ManifestV3}
  */
-const manifest: chrome.runtime.ManifestV3 = {
+const manifest = {
   manifest_version: 3,
   name: packageJson.name,
   version: packageJson.version,
@@ -22,7 +23,7 @@ const manifest: chrome.runtime.ManifestV3 = {
     newtab: 'src/pages/newtab/index.html',
   },
   icons: {
-    '128': 'icon-128.png',
+    128: 'icon-128.png',
   },
   content_scripts: [
     {

--- a/utils/plugins/make-manifest.ts
+++ b/utils/plugins/make-manifest.ts
@@ -10,10 +10,9 @@ const rootDir = resolve(__dirname, '..', '..');
 const distDir = resolve(rootDir, 'dist');
 const manifestFile = resolve(rootDir, 'manifest.js');
 
-export default function makeManifest(config: {
-  getManifest: () => Promise<{ default: chrome.runtime.ManifestV3 }>;
-  contentScriptCssKey?: string;
-}): PluginOption {
+const getManifestWithCacheBurst = () => import(manifestFile + '?' + Date.now().toString());
+
+export default function makeManifest(config: { contentScriptCssKey?: string }): PluginOption {
   function makeManifest(manifest: chrome.runtime.ManifestV3, to: string) {
     if (!fs.existsSync(to)) {
       fs.mkdirSync(to);
@@ -38,7 +37,7 @@ export default function makeManifest(config: {
       this.addWatchFile(manifestFile);
     },
     async writeBundle() {
-      const manifest = await config.getManifest();
+      const manifest = await getManifestWithCacheBurst();
       makeManifest(manifest.default, distDir);
     },
   };

--- a/utils/plugins/watch-rebuild.ts
+++ b/utils/plugins/watch-rebuild.ts
@@ -1,21 +1,12 @@
 import type { PluginOption } from 'vite';
-import { resolve } from 'path';
 import { WebSocket } from 'ws';
 import MessageInterpreter from '../reload/interpreter';
 import { LOCAL_RELOAD_SOCKET_URL } from '../reload/constant';
-
-const rootDir = resolve(__dirname, '..', '..');
-const manifestFile = resolve(rootDir, 'manifest.ts');
-const viteConfigFile = resolve(rootDir, 'vite.config.ts');
 
 export default function watchRebuild(): PluginOption {
   const ws = new WebSocket(LOCAL_RELOAD_SOCKET_URL);
   return {
     name: 'watch-rebuild',
-    buildStart() {
-      this.addWatchFile(manifestFile);
-      this.addWatchFile(viteConfigFile);
-    },
     writeBundle() {
       /**
        * When the build is complete, send a message to the reload server.

--- a/utils/reload/initReloadClient.ts
+++ b/utils/reload/initReloadClient.ts
@@ -6,9 +6,11 @@ let needToUpdate = false;
 export default function initReloadClient({
   watchPath,
   onUpdate,
+  onForceReload,
 }: {
   watchPath: string;
   onUpdate: () => void;
+  onForceReload?: () => void;
 }): WebSocket {
   const socket = new WebSocket(LOCAL_RELOAD_SOCKET_URL);
 
@@ -32,6 +34,10 @@ export default function initReloadClient({
         if (!needToUpdate) {
           needToUpdate = message.path.includes(watchPath);
         }
+        return;
+      }
+      case 'force_reload': {
+        onForceReload?.();
         return;
       }
     }

--- a/utils/reload/injections/script.ts
+++ b/utils/reload/injections/script.ts
@@ -1,10 +1,13 @@
 import initReloadClient from '../initReloadClient';
 
 export default function addHmrIntoScript(watchPath: string) {
+  const reload = () => {
+    chrome.runtime.reload();
+  };
+
   initReloadClient({
     watchPath,
-    onUpdate: () => {
-      chrome.runtime.reload();
-    },
+    onUpdate: reload,
+    onForceReload: reload,
   });
 }

--- a/utils/reload/interpreter/types.ts
+++ b/utils/reload/interpreter/types.ts
@@ -7,10 +7,12 @@ type UpdateRequestMessage = {
 };
 type UpdateCompleteMessage = { type: 'done_update' };
 type BuildCompletionMessage = { type: 'build_complete' };
+type ForceReloadMessage = { type: 'force_reload' };
 
 export type SerializedMessage = string;
 export type WebSocketMessage =
   | UpdateCompleteMessage
   | UpdateRequestMessage
   | UpdatePendingMessage
-  | BuildCompletionMessage;
+  | BuildCompletionMessage
+  | ForceReloadMessage;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -6,8 +6,6 @@ import customDynamicImport from './utils/plugins/custom-dynamic-import';
 import addHmr from './utils/plugins/add-hmr';
 import watchRebuild from './utils/plugins/watch-rebuild';
 
-const getManifestWithCacheBurst = () => import('./manifest.js' + '?' + Date.now().toString());
-
 const rootDir = resolve(__dirname);
 const srcDir = resolve(rootDir, 'src');
 const pagesDir = resolve(srcDir, 'pages');
@@ -32,7 +30,6 @@ export default defineConfig({
   },
   plugins: [
     makeManifest({
-      getManifest: getManifestWithCacheBurst,
       contentScriptCssKey: regenerateCacheInvalidationKey(),
     }),
     react(),

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -5,7 +5,8 @@ import makeManifest from './utils/plugins/make-manifest';
 import customDynamicImport from './utils/plugins/custom-dynamic-import';
 import addHmr from './utils/plugins/add-hmr';
 import watchRebuild from './utils/plugins/watch-rebuild';
-import manifest from './manifest';
+
+const getManifestWithCacheBurst = () => import('./manifest.js' + '?' + Date.now().toString());
 
 const rootDir = resolve(__dirname);
 const srcDir = resolve(rootDir, 'src');
@@ -30,10 +31,11 @@ export default defineConfig({
     },
   },
   plugins: [
-    react(),
-    makeManifest(manifest, {
+    makeManifest({
+      getManifest: getManifestWithCacheBurst,
       contentScriptCssKey: regenerateCacheInvalidationKey(),
     }),
+    react(),
     customDynamicImport(),
     addHmr({ background: enableHmrInBackgroundScript, view: true }),
     isDev && watchRebuild(),
@@ -46,7 +48,7 @@ export default defineConfig({
     minify: isProduction,
     modulePreload: false,
     reportCompressedSize: isProduction,
-    emptyOutDir: false,
+    emptyOutDir: !isDev,
     rollupOptions: {
       input: {
         devtools: resolve(pagesDir, 'devtools', 'index.html'),


### PR DESCRIPTION
Fixed https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/261

- Modify the manifest.ts file with the js extension
- The make-manifest plugin watches the manifest file and rebuilds it
- Disable emptyOutDir option only in dev


