### PR TITLE
docs: added a guide for deleting css files when they are not used

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This boilerplate is made for creating chrome extensions using React and Typescri
 
 ## Add Style Library <a name="add-style-library"></a>
 
-> IMPORTANT: If you want to use css file in the content script, you need to delete the css file in your manifest.js
+> IMPORTANT: If you DO NOT want to use css file in the content script, you need to delete the css file in your manifest.js
 
 ```js
 content_scripts: [

--- a/README.md
+++ b/README.md
@@ -87,6 +87,17 @@ This boilerplate is made for creating chrome extensions using React and Typescri
 
 ## Add Style Library <a name="add-style-library"></a>
 
+> IMPORTANT: If you want to use css file in the content script, you need to delete the css file in your manifest.js
+
+```js
+content_scripts: [
+  {
+    // YOU NEED TO DELETE THIS
+    css: ["assets/css/contentStyle<KEY>.chunk.css"]
+  }
+];
+```
+
 ### Twind <a name="twind"></a>
 
 > The smallest, fastest, most feature complete Tailwind-in-JS solution in existence


### PR DESCRIPTION
fix: #296

Added a short explanation to the README to make it work without CSS.

If you want to clear all contentStyle css related settings, please see the commit below (there may be changes)

https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/compare/main...workaround/missing-css-on-content