### PR TITLE
fix: change color type to not be undefined

### DIFF
--- a/utils/log.ts
+++ b/utils/log.ts
@@ -1,7 +1,7 @@
 type ColorType = 'success' | 'info' | 'error' | 'warning' | keyof typeof COLORS;
 type ValueOf<T> = T[keyof T];
 
-export default function colorLog(message: string, type?: ColorType) {
+export default function colorLog(message: string, type: ColorType) {
   let color: ValueOf<typeof COLORS>;
 
   switch (type) {


### PR DESCRIPTION
Color should be defined, cause if not, 'undefined' could be used as a index
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/64608510/fc61ce4f-1c8f-4584-b651-6252a017a8dd)
