### PR TITLE
feat: add session storage access levels, live update across instances + TSDocs IntelliSense for guidance 

### DIFF
--- a/src/shared/storages/base.ts
+++ b/src/shared/storages/base.ts
@@ -171,6 +171,9 @@ export function createStorage<D>(key: string, fallback: D, config?: StorageConfi
 
   // Listener for live updates from the browser
   async function _updateFromStorageOnChanged(changes: { [key: string]: chrome.storage.StorageChange }) {
+    // Check if the key we are listening for is in the changes object
+    if (changes[key] === undefined) return;
+
     const valueOrUpdate: ValueOrUpdate<D> = changes[key].newValue;
 
     if (cache === valueOrUpdate) return;

--- a/src/shared/storages/base.ts
+++ b/src/shared/storages/base.ts
@@ -1,8 +1,44 @@
+/**
+ * Storage area type for persisting and exchanging data.
+ * @see https://developer.chrome.com/docs/extensions/reference/storage/#overview
+ */
 export enum StorageType {
+  /**
+   * Persist data locally against browser restarts. Will be deleted by uninstalling the extension.
+   * @default
+   */
   Local = 'local',
+  /**
+   * Uploads data to the users account in the cloud and syncs to the users browsers on other devices. Limits apply.
+   */
   Sync = 'sync',
+  /**
+   * Requires an [enterprise policy](https://www.chromium.org/administrators/configuring-policy-for-extensions) with a
+   * json schema for company wide config.
+   */
   Managed = 'managed',
+  /**
+   * Only persist data until the browser is closed. Recommended for service workers which can shutdown anytime and
+   * therefore need to restore their state. Set {@link SessionAccessLevel} for permitting content scripts access.
+   * @implements Chromes [Session Storage](https://developer.chrome.com/docs/extensions/reference/storage/#property-session)
+   */
   Session = 'session',
+}
+
+/**
+ * Global access level requirement for the {@link StorageType.Session} Storage Area.
+ * @implements Chromes [Session Access Level](https://developer.chrome.com/docs/extensions/reference/storage/#method-StorageArea-setAccessLevel)
+ */
+export enum SessionAccessLevel {
+  /**
+   * Storage can only be accessed by Extension pages (not Content scripts).
+   * @default
+   */
+  ExtensionPagesOnly = 'TRUSTED_CONTEXTS',
+  /**
+   * Storage can be accessed by both Extension pages and Content scripts.
+   */
+  ExtensionPagesAndContentScripts = 'TRUSTED_AND_UNTRUSTED_CONTEXTS',
 }
 
 type ValueOrUpdate<D> = D | ((prev: D) => Promise<D> | D);
@@ -14,15 +50,55 @@ export type BaseStorage<D> = {
   subscribe: (listener: () => void) => () => void;
 };
 
-export function createStorage<D>(key: string, fallback: D, config?: { storageType?: StorageType }): BaseStorage<D> {
+type StorageConfig = {
+  /**
+   * Assign the {@link StorageType} to use.
+   * @default Local
+   */
+  storageType?: StorageType;
+  /**
+   * Only for {@link StorageType.Session}: Grant Content scripts access to storage area?
+   * @default false
+   */
+  sessionAccessForContentScripts?: boolean;
+};
+
+/**
+ * If one session storage needs access from content scripts, we need to enable it globally.
+ * @default false
+ */
+let globalSessionAccessLevelFlag: StorageConfig['sessionAccessForContentScripts'] = false;
+
+/**
+ * Checks if the storage permission is granted in the manifest.json.
+ */
+function checkStoragePermission(storageType: StorageType): void {
+  if (chrome.storage[storageType] === undefined) {
+    throw new Error(`Check your storage permission in manifest.json: ${storageType} is not defined`);
+  }
+}
+
+export function createStorage<D>(key: string, fallback: D, config?: StorageConfig): BaseStorage<D> {
   let cache: D | null = null;
   let listeners: Array<() => void> = [];
   const storageType = config?.storageType ?? StorageType.Local;
 
+  // Set global session storage access level for StoryType.Session, only when not already done but needed.
+  if (
+    globalSessionAccessLevelFlag === false &&
+    storageType === StorageType.Session &&
+    config?.sessionAccessForContentScripts === true
+  ) {
+    checkStoragePermission(storageType);
+    chrome.storage[storageType].setAccessLevel({
+      accessLevel: SessionAccessLevel.ExtensionPagesAndContentScripts,
+    });
+    globalSessionAccessLevelFlag = true;
+  }
+
+  // Register life cycle methods
   const _getDataFromStorage = async (): Promise<D> => {
-    if (chrome.storage[storageType] === undefined) {
-      throw new Error(`Check your storage permission into manifest.json: ${storageType} is not defined`);
-    }
+    checkStoragePermission(storageType);
     const value = await chrome.storage[storageType].get([key]);
     return value[key] ?? fallback;
   };

--- a/src/shared/storages/exampleThemeStorage.ts
+++ b/src/shared/storages/exampleThemeStorage.ts
@@ -8,6 +8,7 @@ type ThemeStorage = BaseStorage<Theme> & {
 
 const storage = createStorage<Theme>('theme-storage-key', 'light', {
   storageType: StorageType.Local,
+  liveUpdate: true,
 });
 
 const exampleThemeStorage: ThemeStorage = {


### PR DESCRIPTION
Hi thank you for maintaining this boilerplate :) 

## Session Storage Area and Access Levels
I've noticed that `StorageType.Session` wasn't able to be fully utilized, since they need an [extra access-level step](https://developer.chrome.com/docs/extensions/reference/storage/#type-AccessLevel) in chrome to allow content scripts to also access that storage area. A functionality that is pretty important for background workers processing page content.

So I have added that functionality after noticing. 

## In-Code Guidance via TSDocs
Also, since the whole browser extension landscape is rather confusing for most people, I have added brief [TSDocs](https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html) to the `createStorage` interface and proximal types to provide in editor guidance:

![Kapture 2023-11-30 at 09 39 39](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/2397125/c35c25d6-7e44-4a1e-a1c2-b19cbffe926b)

----- 
### _Cross-Page Live Update_
Originally I wanted to extend your creatStorage solution with an aditional `liveUpdate` flag to be able to keep its many instances (content, popup, side panel, etc) synchronized through properly invalidating the cache with [`onChanged` listeners](https://developer.chrome.com/docs/extensions/reference/storage/#event-onChanged)... but I ran out of time for now.

In its current form, the storage and hooks only get pulled once a page starts... kinda omitting the big advantage of using the storage for keeping state in sync. _Like when you change the color of your `theme`, you probably want that to be applied everywhere directly and not have to open and close pages._

Maybe I can do that at another time. All the best from Berlin!

*Note:*

_Heads up: I am not sure how serious the firefox support in a *chrome* extension boilerplate is, but session storage areas are very differently handled by firefox. See here: [chrome.storage.session in firefox](https://stackoverflow.com/questions/76217047/chrome-storage-session-in-firefox)_