### PR TITLE
Enhance: add a css insertion case to shadow dom

### DIFF
--- a/src/pages/content/ui/index.tsx
+++ b/src/pages/content/ui/index.tsx
@@ -1,6 +1,7 @@
 import { createRoot } from 'react-dom/client';
 import App from '@pages/content/ui/app';
 import refreshOnUpdate from 'virtual:reload-on-update-in-view';
+import injectedStyle from './injected.css?inline';
 
 refreshOnUpdate('pages/content');
 
@@ -14,6 +15,11 @@ rootIntoShadow.id = 'shadow-root';
 
 const shadowRoot = root.attachShadow({ mode: 'open' });
 shadowRoot.appendChild(rootIntoShadow);
+
+/** Inject styles into shadow dom */
+const styleElement = document.createElement('style');
+styleElement.innerHTML = injectedStyle;
+shadowRoot.appendChild(styleElement);
 
 /**
  * https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/pull/174


### PR DESCRIPTION
- https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/307

I've added the CSS injection method presented in the above issue as an example case.

This should be useful if someone wants to use CSS inside the shadow DOM.