### PR TITLE
fix: theme storage toggle failed in Content script example #338

### DIFF
--- a/src/pages/content/injected.ts
+++ b/src/pages/content/injected.ts
@@ -2,7 +2,7 @@ import exampleThemeStorage from '@src/shared/storages/exampleThemeStorage';
 
 async function toggleTheme() {
   console.log('initial theme', await exampleThemeStorage.get());
-  exampleThemeStorage.toggle();
+  await exampleThemeStorage.toggle();
   console.log('toggled theme', await exampleThemeStorage.get());
 }
 

--- a/src/shared/storages/exampleThemeStorage.ts
+++ b/src/shared/storages/exampleThemeStorage.ts
@@ -14,8 +14,8 @@ const storage = createStorage<Theme>('theme-storage-key', 'light', {
 const exampleThemeStorage: ThemeStorage = {
   ...storage,
   // TODO: extends your own methods
-  toggle: () => {
-    storage.set(currentTheme => {
+  toggle: async () => {
+    await storage.set(currentTheme => {
       return currentTheme === 'light' ? 'dark' : 'light';
     });
   },


### PR DESCRIPTION
there is a bug in content script, for storage usage example. theme storage toggle failed according to the log in Chrome Devtool