### PR TITLE
fix: include .tsx, .js, and .jsx files in pnpm lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "dev:firefox": "pnpm build:hmr && (run-p wss build:firefox:watch)",
     "test": "vitest",
     "commitlint": "commitlint --edit",
-    "lint": "eslint src --ext .ts",
+    "lint": "eslint src --ext .ts,.js,.tsx,.jsx",
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --write",
     "prepare": "husky install"


### PR DESCRIPTION
`lint-staged` is already configured to lint not just `*.ts` files but also `*.tsx`, `*.js`, and `*.jsx`.  Also `eslint` is already configured with `eslint-plugin-react`.  So make `pnpm lint` run on the same file types for completeness and consistency.