### PR TITLE
Add sourcemap into preload chunk files

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "husky": "8.0.3",
     "jsdom": "^22.1.0",
     "lint-staged": "15.2.0",
+    "magic-string": "^0.30.6",
     "npm-run-all": "4.1.5",
     "prettier": "3.1.0",
     "rollup": "4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -100,6 +100,9 @@ devDependencies:
   lint-staged:
     specifier: 15.2.0
     version: 15.2.0
+  magic-string:
+    specifier: ^0.30.6
+    version: 0.30.6
   npm-run-all:
     specifier: 4.1.5
     version: 4.1.5
@@ -1436,7 +1439,7 @@ packages:
   /@vitest/snapshot@0.34.6:
     resolution: {integrity: sha512-B3OZqYn6k4VaN011D+ve+AA4whM4QkcwcrwaKwAbyyvS/NB1hCWjFIBQxAQQSQir9/RtyAAGuq+4RJmbn2dH4w==}
     dependencies:
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       pathe: 1.1.1
       pretty-format: 29.7.0
     dev: true
@@ -3980,8 +3983,8 @@ packages:
     hasBin: true
     dev: true
 
-  /magic-string@0.30.5:
-    resolution: {integrity: sha512-7xlpfBaQaP/T6Vh8MO/EqXSW5En6INHEvEXQiuff7Gku0PWjU3uf6w/j9o7O+SpB5fOAkrI5HeoNgwjEO0pFsA==}
+  /magic-string@0.30.6:
+    resolution: {integrity: sha512-n62qCLbPjNjyo+owKtveQxZFZTBm+Ms6YoGD23Wew6Vw337PElFNifQpknPruVRQV57kVShPnLGo9vWxVhpPvA==}
     engines: {node: '>=12'}
     dependencies:
       '@jridgewell/sourcemap-codec': 1.4.15
@@ -5623,7 +5626,7 @@ packages:
       debug: 4.3.4
       jsdom: 22.1.0
       local-pkg: 0.4.3
-      magic-string: 0.30.5
+      magic-string: 0.30.6
       pathe: 1.1.1
       picocolors: 1.0.0
       std-env: 3.5.0

--- a/utils/plugins/inline-vite-preload-script.ts
+++ b/utils/plugins/inline-vite-preload-script.ts
@@ -1,8 +1,11 @@
+import type { PluginOption } from 'vite';
+import MagicString from 'magic-string';
+
 /**
  * solution for multiple content scripts
  * https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/issues/177#issuecomment-1784112536
  */
-export default function inlineVitePreloadScript() {
+export default function inlineVitePreloadScript(): PluginOption {
   let __vitePreload = '';
   return {
     name: 'replace-vite-preload-script-plugin',
@@ -21,6 +24,7 @@ export default function inlineVitePreloadScript() {
       }
       return {
         code: __vitePreload + code.split(`\n`).slice(1).join(`\n`),
+        map: new MagicString(code).generateMap({ hires: true }),
       };
     },
   };


### PR DESCRIPTION
fix #374

## AS-IS

<img width="498" alt="스크린샷 2024-02-03 오후 6 39 46" src="https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/53500778/7ad36889-ed9b-45a2-a63d-cfbeef9ac451">

## TO-BE

<img width="418" alt="스크린샷 2024-02-03 오후 6 40 44" src="https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/53500778/e7574fe3-c7e3-4f85-a4a4-91ad41e44ad4">
