### PR TITLE
Fix type guard to return the correct type

### DIFF
--- a/src/shared/storages/base.ts
+++ b/src/shared/storages/base.ts
@@ -81,7 +81,7 @@ async function updateCache<D>(valueOrUpdate: ValueOrUpdate<D>, cache: D | null):
   }
 
   // Type guard to check in case of a function, if its a Promise
-  function returnsPromise<D>(func: (prev: D) => D | Promise<D>): boolean {
+  function returnsPromise<D>(func: (prev: D) => D | Promise<D>): func is (prev: D) => Promise<D> {
     // Use ReturnType to infer the return type of the function and check if it's a Promise
     return (func as (prev: D) => Promise<D>) instanceof Promise;
   }


### PR DESCRIPTION
if it's Promise, we can use `.then`, `.catch` and `finally`: 
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/958929/63c727e7-b082-4fad-a8c5-b8fe7e47977d)

otherwise, we can't:
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/958929/45699343-0060-4ae0-b6bb-5d7c0d88d832)

Reference: [Using type predicates](https://www.typescriptlang.org/docs/handbook/2/narrowing.html#using-type-predicates)