### PR TITLE
fix: check manifest content scripts existence before iteration

### DIFF
--- a/utils/plugins/make-manifest.ts
+++ b/utils/plugins/make-manifest.ts
@@ -30,7 +30,7 @@ export default function makeManifest(config?: { getCacheInvalidationKey?: () => 
       fs.mkdirSync(to);
     }
     const manifestPath = resolve(to, 'manifest.json');
-    if (cacheKey) {
+    if (cacheKey && manifest.content_scripts) {
       // Naming change for cache invalidation
       manifest.content_scripts.forEach(script => {
         script.css &&= script.css.map(css => css.replace('<KEY>', cacheKey));


### PR DESCRIPTION
Ensure 'forEach' is not called on undefined 'manifest.content_scripts' to prevent the '[make-manifest] Cannot read properties of undefined (reading 'forEach')' error that occurs when the content script section is absent from the manifest.