### PR TITLE
refactor: add support to non trivial types

### DIFF
--- a/src/shared/storages/base.ts
+++ b/src/shared/storages/base.ts
@@ -50,7 +50,7 @@ export type BaseStorage<D> = {
   subscribe: (listener: () => void) => () => void;
 };
 
-type StorageConfig = {
+type StorageConfig<D = string> = {
   /**
    * Assign the {@link StorageType} to use.
    * @default Local
@@ -69,6 +69,20 @@ type StorageConfig = {
    * @default false
    */
   liveUpdate?: boolean;
+  /**
+   * An optional props for converting values from storage and into it.
+   * @default undefined
+   */
+  serialization?: {
+    /**
+     * convert non-native values to string to be saved in storage
+     */
+    serialize: (value: D) => string;
+    /**
+     * convert string value from storage to non-native values
+     */
+    deserialize: (text: string) => D;
+  };
 };
 
 /**
@@ -116,11 +130,13 @@ function checkStoragePermission(storageType: StorageType): void {
 /**
  * Creates a storage area for persisting and exchanging data.
  */
-export function createStorage<D>(key: string, fallback: D, config?: StorageConfig): BaseStorage<D> {
+export function createStorage<D = string>(key: string, fallback: D, config?: StorageConfig<D>): BaseStorage<D> {
   let cache: D | null = null;
   let listeners: Array<() => void> = [];
   const storageType = config?.storageType ?? StorageType.Local;
   const liveUpdate = config?.liveUpdate ?? false;
+  const serialize = config?.serialization?.serialize ?? ((v: D) => v);
+  const deserialize = config?.serialization?.deserialize ?? (v => v as D);
 
   // Set global session storage access level for StoryType.Session, only when not already done but needed.
   if (
@@ -139,7 +155,7 @@ export function createStorage<D>(key: string, fallback: D, config?: StorageConfi
   const _getDataFromStorage = async (): Promise<D> => {
     checkStoragePermission(storageType);
     const value = await chrome.storage[storageType].get([key]);
-    return value[key] ?? fallback;
+    return deserialize(value[key]) ?? fallback;
   };
 
   const _emitChange = () => {
@@ -149,7 +165,7 @@ export function createStorage<D>(key: string, fallback: D, config?: StorageConfi
   const set = async (valueOrUpdate: ValueOrUpdate<D>) => {
     cache = await updateCache(valueOrUpdate, cache);
 
-    await chrome.storage[storageType].set({ [key]: cache });
+    await chrome.storage[storageType].set({ [key]: serialize(cache) });
     _emitChange();
   };
 
@@ -174,7 +190,7 @@ export function createStorage<D>(key: string, fallback: D, config?: StorageConfi
     // Check if the key we are listening for is in the changes object
     if (changes[key] === undefined) return;
 
-    const valueOrUpdate: ValueOrUpdate<D> = changes[key].newValue;
+    const valueOrUpdate: ValueOrUpdate<D> = deserialize(changes[key].newValue);
 
     if (cache === valueOrUpdate) return;
 


### PR DESCRIPTION
Add support for non trivial types like Date, Object and Array

for example, Date, (timestampStorage.ts):
```
import { BaseStorage, createStorage, StorageType } from '@src/shared/storages/base';

type TimestampStorage = BaseStorage<Date | undefined> & {
  mark: () => Promise<void>;
};

const storage = createStorage('timestamp', new Date(), {
  storageType: StorageType.Local,
  liveUpdate: true,
  serialization: {
    deserialize: (text: string) => {
      return new Date(text);
    },
    serialize: (value: Date) => {
      return value?.toISOString();
    },
  },
});

export const timestampStorage: TimestampStorage = {
  ...storage,
  mark: async () => {
    await storage.set(() => {
      return new Date();
    });
  },
};
```

Usage:
```
const timestamp = useStorage(timestampStorage);
timestamp?.toISOString()
```
