### PR TITLE
fix(blog): variable conflict

### DIFF
--- a/utils/plugins/inline-vite-preload-script.ts
+++ b/utils/plugins/inline-vite-preload-script.ts
@@ -23,7 +23,7 @@ export default function inlineVitePreloadScript(): PluginOption {
         }
       }
       return {
-        code: __vitePreload + code.split(`\n`).slice(1).join(`\n`),
+        code: `(function () {${__vitePreload + code.split(`\n`).slice(1).join(`\n`)}})()`,
         map: new MagicString(code).generateMap({ hires: true }),
       };
     },


### PR DESCRIPTION
<img width="716" alt="image" src="https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/38065991/75e0c3c9-828b-4bc5-bc02-3f42ebd63b9f">

When I use the main option, the page variable will conflict with the variable of the plug -in and report an error

The improved packing code is as follows:
<img width="965" alt="image" src="https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/38065991/009fcaf6-d7ea-41ef-b41d-b8725f31a438">
