### PR TITLE
Fix: issue #454

### DIFF
--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -15,7 +15,7 @@
     "build:tsc": "tsc -b tsconfig.build.json",
     "build:rollup": "rollup --config rollup.config.mjs",
     "build": "pnpm run build:tsc && pnpm run build:rollup",
-    "dev-server": "ts-node-esm lib/initReloadServer.ts",
+    "dev-server": "node dist/lib/initReloadServer.js",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --write",

--- a/packages/hmr/tsconfig.build.json
+++ b/packages/hmr/tsconfig.build.json
@@ -3,6 +3,6 @@
   "compilerOptions": {
     "outDir": "dist"
   },
-  "exclude": ["lib/initReloadServer.ts", "lib/injections/**/*"],
+  "exclude": ["lib/injections/**/*"],
   "include": ["lib", "index.ts"]
 }


### PR DESCRIPTION
fix: node ^20 versions breaking change

- https://github.com/TypeStrong/ts-node/issues/1997

use transpiled `js` file instead of original `ts` file.