### PR TITLE
Fix: build error on windows

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.1",
   "description": "chrome extension",
   "scripts": {
-    "clean": "rimraf ../../dist && rimraf .turbo",
+    "clean": "rimraf ../../dist",
     "build": "tsc --noEmit && vite build",
     "build:firefox": "tsc --noEmit && cross-env __FIREFOX__=true vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf dist && turbo clean",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
-    "build-dev-server": "pnpm -F hmr build",
+    "build-dev-server": "pnpm -F=hmr build",
     "dev": "pnpm build-dev-server && cross-env __DEV__=true turbo watch dev --concurrency 20",
     "dev:firefox": "pnpm build-dev-server && cross-env __DEV__=true __FIREFOX__=true turbo watch dev --concurrency 20",
     "test": "turbo test",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite.git"
   },
   "scripts": {
-    "clean": "rimraf dist && rimraf .turbo && turbo clean",
+    "clean": "rimraf dist && turbo clean",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
     "build-dev-server": "pnpm -F hmr build",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "clean": "rimraf dist && rimraf .turbo && turbo clean",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
-    "build-dev-server": "pnpm -F=hmr build",
+    "build-dev-server": "pnpm -F hmr build",
     "dev": "pnpm build-dev-server && cross-env __DEV__=true turbo watch dev --concurrency 20",
     "dev:firefox": "pnpm build-dev-server && cross-env __DEV__=true __FIREFOX__=true turbo watch dev --concurrency 20",
     "test": "turbo test",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -11,7 +11,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist && rimraf ./build && rimraf .turbo",
+    "clean": "rimraf ./dist && rimraf ./build",
     "build": "pnpm run clean && tsc",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "pnpm lint --fix",

--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -11,7 +11,7 @@
   "module": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist && rimraf ./build && rimraf .turbo",
+    "clean": "rimraf ./dist && rimraf ./build",
     "build:tsc": "tsc -b tsconfig.build.json",
     "build:rollup": "rollup --config rollup.config.mjs",
     "build": "pnpm run build:tsc && pnpm run build:rollup",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -11,7 +11,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "tsup index.ts --format esm,cjs --dts --external react,chrome",
     "dev": "tsc -w",
     "lint": "eslint . --ext .ts,.tsx",

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -11,7 +11,7 @@
   "module": "./dist/index.mjs",
   "types": "./dist/index.d.ts",
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "tsup index.ts --format esm,cjs --dts",
     "dev": "tsc -w",
     "lint": "eslint . --ext .ts,.tsx",

--- a/pages/content-ui/package.json
+++ b/pages/content-ui/package.json
@@ -9,7 +9,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build:tailwindcss": "tailwindcss -i src/tailwind-input.css -o src/tailwind-output.css",
     "build": "pnpm build:tailwindcss && pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",

--- a/pages/content/package.json
+++ b/pages/content/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/devtools-panel/package.json
+++ b/pages/devtools-panel/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/devtools/package.json
+++ b/pages/devtools/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/newtab/package.json
+++ b/pages/newtab/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/options/package.json
+++ b/pages/options/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/popup/package.json
+++ b/pages/popup/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",

--- a/pages/sidepanel/package.json
+++ b/pages/sidepanel/package.json
@@ -8,7 +8,7 @@
     "dist/**"
   ],
   "scripts": {
-    "clean": "rimraf ./dist && rimraf .turbo",
+    "clean": "rimraf ./dist",
     "build": "pnpm run clean && tsc --noEmit && vite build",
     "build:watch": "cross-env __DEV__=true vite build -w --mode development",
     "dev": "pnpm build:watch",


### PR DESCRIPTION
fix

- #496

It looks like the removal of 'cache:false' to the turbo folder caused a permission error.

- #492

I think the correct fix is to exclude .turbo from the clean target because when someone rerun the turbo build, they might want to use the cache.