### PR TITLE
Fix logo in the popup page

### DIFF
--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -14,7 +14,7 @@ const Popup = () => {
         backgroundColor: theme === 'light' ? '#eee' : '#222',
       }}>
       <header className="App-header" style={{ color: theme === 'light' ? '#222' : '#eee' }}>
-        <img src={chrome.runtime.getURL('new-tab/logo.svg')} className="App-logo" alt="logo" />
+        <img src={chrome.runtime.getURL('popup/logo.svg')} className="App-logo" alt="logo" />
 
         <p>
           Edit <code>pages/popup/src/Popup.tsx</code> and save to reload.


### PR DESCRIPTION
# In the Popup page wrong logo is used

If we don't need new-tab page and delete it, the popup page will crash like:
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/23140387/82050024-2e7c-4a4e-aa26-952c9baf6b91)

Because the logo in the Popup page is used directly from the new-tab page and not its own.

# Solution 

With the fix, the page work alone!
By simply using the existing logo in the Popup folder.
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/23140387/ef1b4d51-e4ee-4daf-9000-c85f62e7eaa1)
