### PR TITLE
fix: remove messages about empty directory for all modules

### DIFF
--- a/chrome-extension/vite.config.mts
+++ b/chrome-extension/vite.config.mts
@@ -36,6 +36,7 @@ export default defineConfig({
       fileName: 'background',
     },
     outDir,
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/chrome-extension/vite.config.mts
+++ b/chrome-extension/vite.config.mts
@@ -36,7 +36,7 @@ export default defineConfig({
       fileName: 'background',
     },
     outDir,
-    emptyOutDir: true,
+    emptyOutDir: false,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/content-ui/vite.config.mts
+++ b/pages/content-ui/vite.config.mts
@@ -35,6 +35,7 @@ export default defineConfig({
       fileName: 'index',
     },
     outDir: resolve(rootDir, '..', '..', 'dist', 'content-ui'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/content/vite.config.mts
+++ b/pages/content/vite.config.mts
@@ -24,6 +24,7 @@ export default defineConfig({
       fileName: 'index',
     },
     outDir: resolve(rootDir, '..', '..', 'dist', 'content'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/devtools-panel/vite.config.mts
+++ b/pages/devtools-panel/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'devtools-panel'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/devtools/vite.config.mts
+++ b/pages/devtools/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'devtools'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/new-tab/vite.config.mts
+++ b/pages/new-tab/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'new-tab'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/options/vite.config.mts
+++ b/pages/options/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'options'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/popup/vite.config.mts
+++ b/pages/popup/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'popup'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/side-panel/vite.config.mts
+++ b/pages/side-panel/vite.config.mts
@@ -20,6 +20,7 @@ export default defineConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'side-panel'),
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,


### PR DESCRIPTION
It's necessary because the build folders are located outside root dir
![image](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/assets/64608510/1fb0ef4e-6115-436f-9c41-1d3dcb9325f2)

solving #526 