### PR TITLE
Use turborepo tui

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -1,5 +1,6 @@
 {
   "$schema": "https://turbo.build/schema.json",
+  "ui": "tui",
   "tasks": {
     "ready": {
       "outputs": ["dist/**", "build/**"]


### PR DESCRIPTION
https://turbo.build/repo/docs/reference/configuration#ui

https://github.com/vercel/turbo/releases/tag/v2.0.6

The default UI has been restored in TurboRepo 2.0.6.
Now, to use TUI, we need to use the settings.

<img width="1268" alt="스크린샷 2024-07-12 오후 7 53 02" src="https://github.com/user-attachments/assets/cb78b2a7-0000-4935-9a50-a624458843f5">
