### PR TITLE
feat: add 'clean:node_modules' and 'clean:install' commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite.git"
   },
   "scripts": {
-    "clean": "rimraf dist && turbo clean",
+    "clean": "rimraf dist && rimraf .turbo && turbo clean",
+    "clean:node_modules": "rimraf **/node_modules && rimraf ./node_modules",
+    "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
     "dev-server": "pnpm -F hmr ready && pnpm -F hmr dev",


### PR DESCRIPTION
As we know, pnpm hasn't implement `pnpm clean-install` yet.

https://github.com/pnpm/pnpm/issues/6100

<img width="542" alt="스크린샷 2024-07-16 오전 11 56 58" src="https://github.com/user-attachments/assets/64a5d0f6-7fd9-44f6-854b-116b34cdb9cd">


For convenience, add `clean:install` command.

fix #523


