### PR TITLE
fix/node_modules cleaning script

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "scripts": {
     "clean:node_modules": "pnpx rimraf --glob **/node_modules",
-    "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo",
+    "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo && pnpm clean:node_modules",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,9 @@
     "url": "https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite.git"
   },
   "scripts": {
+    "clean:node_modules": "rimraf --glob **/node_modules",
     "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo",
+    "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
     "zip": "turbo zip",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   },
   "scripts": {
     "clean:node_modules": "pnpx rimraf --glob **/node_modules",
-    "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo && pnpm clean:node_modules",
+    "clean:turbo": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo",
+    "clean": "pnpm clean:turbo && pnpm clean:node_modules" ,
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite.git"
   },
   "scripts": {
-    "clean:node_modules": "rimraf --glob **/node_modules",
+    "clean:node_modules": "pnpx rimraf --glob **/node_modules",
     "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo",
     "clean:install": "pnpm clean:node_modules && pnpm install --frozen-lockfile",
     "build": "turbo build",
@@ -61,7 +61,8 @@
     "turbo": "^2.0.12",
     "typescript": "5.5.4",
     "vite": "5.4.1",
-    "run-script-os": "^1.1.6"
+    "run-script-os": "^1.1.6",
+    "rimraf": "^6.0.1"
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx}": [


### PR DESCRIPTION
I need to add --glob flag.

But after all, error occur because of the lack of node_modules when rimraf is removed by itself xD.

Rimraf suggest to install it globally, i have done postinstall script, which install it automatically with 'pnpm i' :)