### PR TITLE
fix: chrome reference error when use storage in ui package

### DIFF
--- a/packages/storage/build.mjs
+++ b/packages/storage/build.mjs
@@ -1,0 +1,15 @@
+import * as esbuild from 'esbuild';
+
+/**
+ * @type { import("esbuild").BuildOptions }
+ */
+const buildOptions = {
+  entryPoints: ['./index.ts', './lib/**/*.ts', './lib/**/*.tsx'],
+  tsconfig: './tsconfig.json',
+  bundle: false,
+  target: 'es6',
+  outdir: './dist',
+  sourcemap: true,
+};
+
+await esbuild.build(buildOptions);

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -7,14 +7,11 @@
   "files": [
     "dist/**"
   ],
-  "main": "./dist/cjs/index.js",
-  "module": "./dist/esm/index.js",
+  "main": "./dist/index.js",
   "types": "index.ts",
   "scripts": {
     "clean": "rimraf ./dist",
-    "build:esm": "tsc --module es2015 --target es5 --outDir dist/esm",
-    "build:cjs": "tsc --module commonjs --target es5 --outDir dist/cjs",
-    "ready": "pnpm build:esm && pnpm build:cjs",
+    "ready": "node build.mjs",
     "lint": "eslint . --ext .ts,.tsx",
     "lint:fix": "pnpm lint --fix",
     "prettier": "prettier . --write --ignore-path ../../.prettierignore",

--- a/packages/vite-config/lib/withPageConfig.mjs
+++ b/packages/vite-config/lib/withPageConfig.mjs
@@ -28,7 +28,7 @@ export function withPageConfig(config) {
           sourcemap: isDev,
           minify: isProduction,
           reportCompressedSize: isProduction,
-          emptyOutDir: true,
+          emptyOutDir: isProduction,
           watch: watchOption,
           rollupOptions: {
             external: ['chrome'],


### PR DESCRIPTION
If you use a package like storage in a UI package, for example, you will get a reference error during the build phase.

I found that the chrome reference error occurs during the `processTailwindFeatures` execution of tailwindcss. To avoid this, I look for references to chrome in globlaThis, and add fallback logic.

This is a temporary measure until we have a better way.