### PR TITLE
Better firefox support

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
     "zip": "turbo zip",
+    "zip:firefox": "cross-env __FIREFOX__=true turbo zip",
     "dev-server": "pnpm -F hmr ready && pnpm -F hmr dev",
     "dev": "turbo ready && turbo watch dev --concurrency 20",
     "dev:firefox": "turbo ready && cross-env __FIREFOX__=true turbo watch dev --concurrency 20",

--- a/packages/dev-utils/lib/manifest-parser/impl.ts
+++ b/packages/dev-utils/lib/manifest-parser/impl.ts
@@ -25,6 +25,12 @@ function convertToFirefoxCompatibleManifest(manifest: Manifest) {
   manifestCopy.content_security_policy = {
     extension_pages: "script-src 'self'; object-src 'self'",
   };
+  manifestCopy.browser_specific_settings = {
+    gecko: {
+      id: 'example@example.com',
+      strict_min_version: '109.0',
+    },
+  };
   delete manifestCopy.options_page;
   return manifestCopy as Manifest;
 }

--- a/packages/zipper/index.ts
+++ b/packages/zipper/index.ts
@@ -6,5 +6,5 @@ import { zipBundle } from './lib/zip-bundle';
 zipBundle({
   distDirectory: resolve(__dirname, '../../dist'),
   buildDirectory: resolve(__dirname, '../../dist-zip'),
-  distDirectoryName: 'extension',
+  archiveName: process.env.__FIREFOX__ ? 'extension.xpi' : 'extension.zip',
 });

--- a/packages/zipper/lib/zip-bundle/index.ts
+++ b/packages/zipper/lib/zip-bundle/index.ts
@@ -1,5 +1,5 @@
 import { createReadStream, createWriteStream, existsSync, mkdirSync } from 'fs';
-import { resolve, relative } from 'path';
+import { resolve, posix } from 'path';
 import glob from 'fast-glob';
 import { AsyncZipDeflate, Zip } from 'fflate';
 
@@ -94,10 +94,13 @@ export const zipBundle = async (
       if (aborted) return;
 
       const absPath = resolve(distDirectory, file);
-      const relPath = relative(distDirectory, absPath); // Get the relative path
+      const absPosixPath = posix.resolve(distDirectory, file);
+      const relPosixPath = posix.relative(distDirectory, absPosixPath);
+
+      console.log(`Adding file: ${relPosixPath}`);
       streamFileToZip(
         absPath,
-        relPath, // Use relative path
+        relPosixPath, // Use relative path
         zip,
         () => {
           aborted = true;

--- a/packages/zipper/lib/zip-bundle/index.ts
+++ b/packages/zipper/lib/zip-bundle/index.ts
@@ -98,7 +98,7 @@ export const zipBundle = async (
       console.log(`Adding file: ${relPosixPath}`);
       streamFileToZip(
         absPath,
-        relPosixPath, // Use relative path
+        relPosixPath,
         zip,
         () => {
           aborted = true;

--- a/packages/zipper/lib/zip-bundle/index.ts
+++ b/packages/zipper/lib/zip-bundle/index.ts
@@ -45,17 +45,17 @@ export const zipBundle = async (
   {
     distDirectory,
     buildDirectory,
-    distDirectoryName,
+    archiveName,
   }: {
     distDirectory: string;
     buildDirectory: string;
-    distDirectoryName: string;
+    archiveName: string;
   },
   withMaps = false,
 ): Promise<void> => {
   ensureBuildDirectoryExists(buildDirectory);
 
-  const zipFilePath = resolve(buildDirectory, `${distDirectoryName}.zip`);
+  const zipFilePath = resolve(buildDirectory, archiveName);
   const output = createWriteStream(zipFilePath);
 
   const fileList = await glob(

--- a/packages/zipper/lib/zip-bundle/index.ts
+++ b/packages/zipper/lib/zip-bundle/index.ts
@@ -74,8 +74,6 @@ export const zipBundle = async (
     let totalSize = 0;
     const timer = Date.now();
     const zip = new Zip((err, data, final) => {
-      if (aborted) return;
-
       if (err) {
         pReject(err);
       } else {

--- a/pages/content-runtime/lib/root.tsx
+++ b/pages/content-runtime/lib/root.tsx
@@ -15,25 +15,23 @@ export function mount() {
 
   const shadowRoot = root.attachShadow({ mode: 'open' });
 
-  /** Inject styles into shadow dom */
-  const globalStyleSheet = new CSSStyleSheet();
-  globalStyleSheet.replaceSync(injectedStyle);
-  shadowRoot.adoptedStyleSheets = [globalStyleSheet];
+  if (navigator.userAgent.includes('Firefox')) {
+    /**
+     * In the firefox environment, adoptedStyleSheets cannot be used due to the bug
+     * @url https://bugzilla.mozilla.org/show_bug.cgi?id=1770592
+     *
+     * Injecting styles into the document, this may cause style conflicts with the host page
+     */
+    const styleElement = document.createElement('style');
+    styleElement.innerHTML = injectedStyle;
+    shadowRoot.appendChild(styleElement);
+  } else {
+    /** Inject styles into shadow dom */
+    const globalStyleSheet = new CSSStyleSheet();
+    globalStyleSheet.replaceSync(injectedStyle);
+    shadowRoot.adoptedStyleSheets = [globalStyleSheet];
+  }
 
-  /**
-   * In the firefox environment, the adoptedStyleSheets bug may prevent style from being applied properly.
-   *
-   * @url https://bugzilla.mozilla.org/show_bug.cgi?id=1770592
-   * @url https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/pull/174
-   *
-   * Please refer to the links above and try the following code if you encounter the issue.
-   *
-   * ```ts
-   * const styleElement = document.createElement('style');
-   * styleElement.innerHTML = injectedStyle;
-   * shadowRoot.appendChild(styleElement);
-   * ```
-   */
   shadowRoot.appendChild(rootIntoShadow);
   createRoot(rootIntoShadow).render(<App />);
 }

--- a/pages/content-ui/src/index.tsx
+++ b/pages/content-ui/src/index.tsx
@@ -14,24 +14,22 @@ rootIntoShadow.id = 'shadow-root';
 
 const shadowRoot = root.attachShadow({ mode: 'open' });
 
-/** Inject styles into shadow dom */
-const globalStyleSheet = new CSSStyleSheet();
-globalStyleSheet.replaceSync(tailwindcssOutput);
-shadowRoot.adoptedStyleSheets = [globalStyleSheet];
-/**
- * In the firefox environment, the adoptedStyleSheets bug may prevent style from being applied properly.
- *
- * @url https://bugzilla.mozilla.org/show_bug.cgi?id=1770592
- * @url https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/pull/174
- *
- * Please refer to the links above and try the following code if you encounter the issue.
- *
-
- * const styleElement = document.createElement('style');
- * styleElement.innerHTML = tailwindcssOutput;
- * shadowRoot.appendChild(styleElement);
- * ```
- */
+if (navigator.userAgent.includes('Firefox')) {
+  /**
+   * In the firefox environment, adoptedStyleSheets cannot be used due to the bug
+   * @url https://bugzilla.mozilla.org/show_bug.cgi?id=1770592
+   *
+   * Injecting styles into the document, this may cause style conflicts with the host page
+   */
+  const styleElement = document.createElement('style');
+  styleElement.innerHTML = tailwindcssOutput;
+  shadowRoot.appendChild(styleElement);
+} else {
+  /** Inject styles into shadow dom */
+  const globalStyleSheet = new CSSStyleSheet();
+  globalStyleSheet.replaceSync(tailwindcssOutput);
+  shadowRoot.adoptedStyleSheets = [globalStyleSheet];
+}
 
 shadowRoot.appendChild(rootIntoShadow);
 createRoot(rootIntoShadow).render(<App />);

--- a/pages/devtools/src/index.ts
+++ b/pages/devtools/src/index.ts
@@ -1,6 +1,6 @@
 try {
   console.log("Edit 'pages/devtools/src/index.ts' and save to reload.");
-  chrome.devtools.panels.create('Dev Tools', 'icon-34.png', 'devtools-panel/index.html');
+  chrome.devtools.panels.create('Dev Tools', '/icon-34.png', '/devtools-panel/index.html');
 } catch (e) {
   console.error(e);
 }

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -13,12 +13,7 @@ const Popup = () => {
 
     await chrome.scripting.executeScript({
       target: { tabId: tab.id! },
-      /**
-       * If you are using Firefox, you should use a relative path. :(
-       * @example
-       * files: ['../content-runtime/index.iife.js'],
-       */
-      files: ['content-runtime/index.iife.js'],
+      files: ['/content-runtime/index.iife.js'],
     });
   };
 

--- a/turbo.json
+++ b/turbo.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://turbo.build/schema.json",
   "ui": "tui",
+  "globalEnv": ["__FIREFOX__"],
   "tasks": {
     "ready": {
       "outputs": [
@@ -16,18 +17,12 @@
         "dist/**",
         "build/**"
       ],
-      "env": [
-        "__FIREFOX__"
-      ],
       "persistent": true
     },
     "build": {
       "dependsOn": [
         "^build",
         "ready"
-      ],
-      "env": [
-        "__FIREFOX__"
       ],
       "outputs": [
         "../../dist/**",
@@ -37,7 +32,7 @@
     },
     "zip": {
       "dependsOn": [
-        "^build"
+        "build"
       ],
       "cache": false
     },


### PR DESCRIPTION
Firefox support improvement

## Priority*

- [x] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
I was thinking to add e2e tests for both browsers. For Firefox running in Puppeter extension needs to be zipped and installed.
This PR allows zipping of Firefox extension and cleans Firefox related turbojs scripts

## Changes
feat: zipped firefox extension ready to work 
fix: zipper bundles on windows with posix slashes
refactor: zip command respects firefox settings
refactor: extension scripts depend on turbojs global firefox environment variable 

## How to check the feature
<!-- Describe how to check the feature in detail -->
turbojs scripts refactoring:
(run `pnpm dev`) check Chrome can load extension (Firefox can't) [chrome://extensions/](chrome://extensions/)
(run `pnpm dev:firefox`) Firefox can load extension (Chrome can't)  [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)

zipper work:
(run `pnpm zip`) Chrome extension packed. Can be installed by drag-and-drop to [chrome://extensions/](chrome://extensions/)
(run `pnpm zip:firefox`) Firefox extension packed. Extension can be installed by "Load Temporary Add-on" to [about:debugging#/runtime/this-firefox](about:debugging#/runtime/this-firefox)

Also have to change turbojs dependsOn, since changing FIREFOX variable didn't cleaned old dist folder resulting in wrong zip bundle.

## Reference
globalEnv: Changes to the values of any environment variables in this list will change the hash for all tasks.
Firefox doesn't allow backslashes in the zip file. <https://github.com/mozilla/addons/issues/8879>
