### PR TITLE
fix: remove unused .tsx files pattern from storage/esbuild

### DIFF
--- a/packages/storage/build.mjs
+++ b/packages/storage/build.mjs
@@ -4,7 +4,7 @@ import * as esbuild from 'esbuild';
  * @type { import("esbuild").BuildOptions }
  */
 const buildOptions = {
-  entryPoints: ['./index.ts', './lib/**/*.ts', './lib/**/*.tsx'],
+  entryPoints: ['./index.ts', './lib/**/*.ts'],
   tsconfig: './tsconfig.json',
   bundle: false,
   target: 'es6',


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Avoid warning displaying.
Also on ```storage``` for 99% .tsx files will not be stored.

## Changes*
Removed ``` './lib/**/*.tsx' ``` from esbuild config

## How to check the feature
Not necessary

## Reference
![Zrzut ekranu 2024-08-08 113510](https://github.com/user-attachments/assets/979c7eaa-1765-40b4-be6a-72ec05a1ec74)
