### PR TITLE
fix/not permitted unlink for 'pnpm clean'

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "url": "https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite.git"
   },
   "scripts": {
-    "clean": "rimraf dist && rimraf .turbo && turbo clean",
+    "clean": "turbo clean && turbo daemon stop && rimraf dist && rimraf .turbo",
     "build": "turbo build",
     "build:firefox": "cross-env __FIREFOX__=true turbo build",
     "zip": "turbo zip",


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [x] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Give users possibility to use ```pnpm clean``` script in 100% :)

## Changes*
Add shut down turbo daemon before rimraf 

## How to check the feature
run ```pnpm clean```

## Reference
I was thinking also about total shut down of daemon, but i'm not sure, we're really need it.
@Jonghakseo If we don't need it, we can turn it off globally, but it isn't working properly for now.
I was sent question to turborepo community, let's wait for response :)
https://github.com/vercel/turbo/pull/8728#issuecomment-2275534895