### PR TITLE
fix/handle error on injecting script from popup

### DIFF
--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -11,10 +11,16 @@ const Popup = () => {
   const injectContentScript = async () => {
     const [tab] = await chrome.tabs.query({ currentWindow: true, active: true });
 
-    await chrome.scripting.executeScript({
-      target: { tabId: tab.id! },
-      files: ['/content-runtime/index.iife.js'],
-    });
+    await chrome.scripting
+      .executeScript({
+        target: { tabId: tab.id! },
+        files: ['/content-runtime/index.iife.js'],
+      })
+      .catch(err => {
+        if (err.message.includes('Cannot access a chrome:// URL')) {
+          alert('You cannot inject script here!');
+        }
+      });
   };
 
   return (


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to handle that, because error was going to extension console, which our users don't like.

Also devs on dev process, can forget/don't know about that error and users could be shocked why script isn't working here :)

## Changes*
I done an simple alert notification to let users know what's wrong.

It's more meaningful than before error.
That's simply but it's sufficient IMO, because each dev can handle that in their way

## How to check the feature
Try to inject script from popup in place where it's not possible, e.g chrome home page