### PR TITLE
pEnhance] add throw when websocket server error

### DIFF
--- a/packages/hmr/lib/initializers/initReloadServer.ts
+++ b/packages/hmr/lib/initializers/initReloadServer.ts
@@ -36,8 +36,9 @@ function initReloadServer() {
     });
   });
 
-  wss.on('error', () => {
+  wss.on('error', error => {
     console.error(`[HMR] Failed to start server at ${LOCAL_RELOAD_SOCKET_URL}`);
+    throw error;
   });
 }
 


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [x] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

It's not easy to find error when wss crashed.

## Changes*

Throw error when wss onError


## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any changes to the screen, please attach a screenshot for easy identification. -->


## Reference
<!-- Any helpful information for understanding the PR. -->
