### PR TITLE
fix: add `vite.config.mts.timestamp` files to `.gitignore`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@
 # compiled
 chrome-extension/public/manifest.json
 **/tailwind-output.css
+
+# vite timestamp (because of bug from lib, remove it after fix will have been realased)
+**/vite.config.mts.timestamp-*


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [x] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I've done it because of the conversation on Discord, it's annoying we need to remove it everytime.

For fix we need to wait a while:
https://github.com/vitejs/vite/issues/13267

## Changes*
I've added `vite.config.mts.timestamp` files to `.gitignore`
