### PR TITLE
fix: icon error on injecting notification on chrome

### DIFF
--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -5,7 +5,7 @@ import type { ComponentPropsWithoutRef } from 'react';
 
 const notificationOptions = {
   type: 'basic',
-  iconUrl: 'icon-34.png',
+  iconUrl: chrome.runtime.getURL('icon-34.png'),
   title: 'Injecting content script error',
   message: 'You cannot inject script here!',
 } as const;


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [x] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I haven't tested it on chrome, i'm sure i've done it, but now i see i forgot, sorry

## Changes*
Now icon and entire notification for `chrome` works :)

## How to check the feature
Try to inject `runtime-script` inside `about:` path on Firefox or `chrome:` on Chrome