### PR TITLE
Fix: use module esnext

### DIFF
--- a/packages/tsconfig/base.json
+++ b/packages/tsconfig/base.json
@@ -4,6 +4,7 @@
   "compilerOptions": {
     "allowJs": true,
     "noEmit": true,
+    "module": "esnext",
     "downlevelIteration": true,
     "isolatedModules": true,
     "strict": true,
@@ -17,10 +18,6 @@
     "resolveJsonModule": true,
     "noImplicitReturns": true,
     "jsx": "react-jsx",
-    "lib": [
-      "DOM",
-      "ESNext"
-    ]
+    "lib": ["DOM", "ESNext"]
   }
 }
-

--- a/pages/devtools-panel/package.json
+++ b/pages/devtools-panel/package.json
@@ -28,5 +28,11 @@
     "@extension/vite-config": "workspace:*",
     "postcss-load-config": "^6.0.1",
     "cross-env": "^7.0.3"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/pages/devtools-panel/postcss.config.ts
+++ b/pages/devtools-panel/postcss.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'postcss-load-config';
-
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-} as Config;

--- a/pages/new-tab/package.json
+++ b/pages/new-tab/package.json
@@ -31,5 +31,11 @@
     "sass": "1.77.8",
     "postcss-load-config": "^6.0.1",
     "cross-env": "^7.0.3"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/pages/new-tab/postcss.config.ts
+++ b/pages/new-tab/postcss.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'postcss-load-config';
-
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-} as Config;

--- a/pages/options/package.json
+++ b/pages/options/package.json
@@ -29,5 +29,11 @@
     "@extension/vite-config": "workspace:*",
     "postcss-load-config": "^6.0.1",
     "cross-env": "^7.0.3"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/pages/options/postcss.config.ts
+++ b/pages/options/postcss.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'postcss-load-config';
-
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-} as Config;

--- a/pages/popup/package.json
+++ b/pages/popup/package.json
@@ -29,5 +29,11 @@
     "@extension/vite-config": "workspace:*",
     "postcss-load-config": "^6.0.1",
     "cross-env": "^7.0.3"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/pages/popup/postcss.config.ts
+++ b/pages/popup/postcss.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'postcss-load-config';
-
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-} as Config;

--- a/pages/side-panel/package.json
+++ b/pages/side-panel/package.json
@@ -28,5 +28,11 @@
     "@extension/vite-config": "workspace:*",
     "postcss-load-config": "^6.0.1",
     "cross-env": "^7.0.3"
+  },
+  "postcss": {
+    "plugins": {
+      "tailwindcss": {},
+      "autoprefixer": {}
+    }
   }
 }

--- a/pages/side-panel/postcss.config.ts
+++ b/pages/side-panel/postcss.config.ts
@@ -1,8 +1,0 @@
-import type { Config } from 'postcss-load-config';
-
-export default {
-  plugins: {
-    tailwindcss: {},
-    autoprefixer: {},
-  },
-} as Config;


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [x] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

Again #733 but addressed [issue](https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/pull/733#issuecomment-2346546612)

## Changes*

- Set module: esnext in base.json
- move all postcss.config.ts to each package.json

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any changes to the screen, please attach a screenshot for easy identification. -->

PostCss... it works

<img width="296" alt="스크린샷 2024-09-13 오전 1 41 50" src="https://github.com/user-attachments/assets/5433a4e1-75a9-4116-b652-fb14d558d4be">


## Reference
<!-- Any helpful information for understanding the PR. -->
