### PR TITLE
fix: remove `type-check` from GH CI build action

### DIFF
--- a/.github/workflows/build-zip.yml
+++ b/.github/workflows/build-zip.yml
@@ -20,7 +20,7 @@ jobs:
 
       - run: pnpm install --frozen-lockfile --prefer-offline
 
-      - run: pnpm type-check && pnpm build
+      - run: pnpm build
 
       - uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [x] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
As i've talked to you, this will be a problem in the future, now is the future :)
https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/pull/699#issuecomment-2351124386

## Changes*
I've removed `type-check` from GH CI build action