### PR TITLE
Fix background script path in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,7 @@ You have to do it on every browser launch.</i>
 Main app with background script, manifest
 
 - `manifest.js` - manifest for chrome extension
-- `lib/background` - [background script](https://developer.chrome.com/docs/extensions/mv3/background_pages/) for chrome
+- `src/background` - [background script](https://developer.chrome.com/docs/extensions/mv3/background_pages/) for chrome
   extension (`background.service_worker` in
   manifest.json)
 - `public/content.css` - content css for user's page injection


### PR DESCRIPTION
Background script folder is src/background not lib/background

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.