### PR TITLE
Add ESLint plugin with Tailwind CSS support

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,7 +2,7 @@
   "env": {
     "browser": true,
     "es6": true,
-    "node": true
+    "node": true,
   },
   "extends": [
     "eslint:recommended",
@@ -11,39 +11,30 @@
     "plugin:react-hooks/recommended",
     "plugin:import/recommended",
     "plugin:jsx-a11y/recommended",
-    "prettier"
+    "plugin:tailwindcss/recommended",
+    "prettier",
   ],
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "ecmaFeatures": {
-      "jsx": true
+      "jsx": true,
     },
     "ecmaVersion": "latest",
-    "sourceType": "module"
+    "sourceType": "module",
   },
-  "plugins": [
-    "react",
-    "@typescript-eslint",
-    "react-hooks",
-    "import",
-    "jsx-a11y",
-    "prettier"
-  ],
+  "plugins": ["react", "@typescript-eslint", "react-hooks", "import", "jsx-a11y", "prettier"],
   "settings": {
     "react": {
-      "version": "detect"
-    }
+      "version": "detect",
+    },
   },
   "rules": {
     "react/react-in-jsx-scope": "off",
     "import/no-unresolved": "off",
-    "@typescript-eslint/consistent-type-imports": "error"
+    "@typescript-eslint/consistent-type-imports": "error",
   },
   "globals": {
-    "chrome": "readonly"
+    "chrome": "readonly",
   },
-  "ignorePatterns": [
-    "watch.js",
-    "dist/**"
-  ]
+  "ignorePatterns": ["watch.js", "dist/**"],
 }

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "update-version": "bash update_version.sh"
   },
   "dependencies": {
+    "eslint-plugin-tailwindcss": "^3.17.4",
     "react": "18.3.1",
     "react-dom": "18.3.1"
   },

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -11,7 +11,7 @@ export default function App() {
   }, []);
 
   return (
-    <div className="flex items-center justify-between gap-2 bg-blue-100 rounded py-1 px-2">
+    <div className="flex items-center justify-between gap-2 rounded bg-blue-100 px-2 py-1">
       <div className="flex gap-1 text-blue-500">
         Edit <strong className="text-blue-700">pages/content-ui/src/app.tsx</strong> and save to reload.
       </div>

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -11,7 +11,7 @@ const Options = () => {
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 
   return (
-    <div className={`App ${isLight ? 'text-gray-900 bg-slate-50' : 'text-gray-100 bg-gray-800'}`}>
+    <div className={`App ${isLight ? 'bg-slate-50 text-gray-900' : 'bg-gray-800 text-gray-100'}`}>
       <button onClick={goGithubSite}>
         <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
       </button>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      eslint-plugin-tailwindcss:
+        specifier: ^3.17.4
+        version: 3.17.4(tailwindcss@3.4.11(ts-node@10.9.2(@swc/core@1.7.25)(@types/node@20.16.5)(typescript@5.5.4)))
       react:
         specifier: 18.3.1
         version: 18.3.1
@@ -2186,6 +2189,12 @@ packages:
     engines: {node: '>=4'}
     peerDependencies:
       eslint: ^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7
+
+  eslint-plugin-tailwindcss@3.17.4:
+    resolution: {integrity: sha512-gJAEHmCq2XFfUP/+vwEfEJ9igrPeZFg+skeMtsxquSQdxba9XRk5bn0Bp9jxG1VV9/wwPKi1g3ZjItu6MIjhNg==}
+    engines: {node: '>=18.12.0'}
+    peerDependencies:
+      tailwindcss: ^3.4.0
 
   eslint-scope@5.1.1:
     resolution: {integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==}
@@ -6123,6 +6132,12 @@ snapshots:
       semver: 6.3.1
       string.prototype.matchall: 4.0.11
       string.prototype.repeat: 1.0.0
+
+  eslint-plugin-tailwindcss@3.17.4(tailwindcss@3.4.11(ts-node@10.9.2(@swc/core@1.7.25)(@types/node@20.16.5)(typescript@5.5.4))):
+    dependencies:
+      fast-glob: 3.3.2
+      postcss: 8.4.47
+      tailwindcss: 3.4.11(ts-node@10.9.2(@swc/core@1.7.25)(@types/node@20.16.5)(typescript@5.5.4))
 
   eslint-scope@5.1.1:
     dependencies:


### PR DESCRIPTION
# Add ESLint plugin with Tailwind CSS support and unify project configuration

## Priority*
- [ ] High: This PR needs to be merged first for other tasks.
- [ ] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
This PR adds ESLint with Tailwind CSS support for automatically sorting tailwind classes.

## Changes*
1. Install `eslint-plugin-tailwindcss` as a dev dependency in the root `package.json`.
2. Update root `package.json` with new lint scripts for the entire project.

## How to check the feature
1. Pull the changes and run `pnpm install` to update dependencies.
2. Run `pnpm run lint` to check if ESLint runs successfully across the entire project.
3. Make a small change that violates a Tailwind CSS rule (e.g., use an invalid class name) in a React component.
4. Run `pnpm run lint` again to verify that the Tailwind CSS linting catches the error.
5. Run `pnpm run lint:fix` to check if auto-fixable issues are corrected.
6. Try running `pnpm dev` and `pnpm build` to ensure the new setup doesn't break existing scripts.

## Reference
- [eslint-plugin-tailwindcss documentation](https://github.com/francoismassart/eslint-plugin-tailwindcss)