### PR TITLE
Fix set storage before init cache

### DIFF
--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -58,6 +58,7 @@ function checkStoragePermission(storageEnum: StorageEnum): void {
  */
 export function createStorage<D = string>(key: string, fallback: D, config?: StorageConfig<D>): BaseStorage<D> {
   let cache: D | null = null;
+  let initedCache = false;
   let listeners: Array<() => void> = [];
 
   const storageEnum = config?.storageEnum ?? StorageEnum.Local;
@@ -101,6 +102,9 @@ export function createStorage<D = string>(key: string, fallback: D, config?: Sto
   };
 
   const set = async (valueOrUpdate: ValueOrUpdate<D>) => {
+    if (initedCache === false) {
+      cache = await get();
+    }
     cache = await updateCache(valueOrUpdate, cache);
 
     await chrome?.storage[storageEnum].set({ [key]: serialize(cache) });
@@ -121,6 +125,7 @@ export function createStorage<D = string>(key: string, fallback: D, config?: Sto
 
   get().then(data => {
     cache = data;
+    initedCache = true;
     _emitChange();
   });
 


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` Please fill in the required items.

## Priority*

- [ ] High: This PR needs to be merged first for other tasks.
- [x] Middle: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

## Changes*
Add the inited state and make sure that the callback in the set function can get the correct cache value.

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any changes to the screen, please attach a screenshot for easy identification. -->


## Reference
<!-- Any helpful information for understanding the PR. -->
