### PR TITLE
docs: fix access to env var using VITE_ prefix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ To add an environment variable:
 3. Edit `./vite-env.d.ts` and in the `ImportMetaEnv` interface, add your variable with the appropriate type, e.g.
 
    `readonly VITE_MY_API_KEY: string;`
-4. Then you can read the variable via `import.meta.env.MY_API_KEY` (learn more at [Env Variables and Modes](https://vite.dev/guide/env-and-mode))
+4. Then you can read the variable via `import.meta.env.VITE_MY_API_KEY` (learn more at [Env Variables and Modes](https://vite.dev/guide/env-and-mode))
 
 #### If you want to set it for each package independently:
 


### PR DESCRIPTION
## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
In my previous large PR I forgot to add the `VITE_` prefix to accessing the env var via import.meta.env.

## Reference

https://vite.dev/guide/env-and-mode#env-files
