### PR TITLE
Enhance: comportable pnpm zip

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ Some shared packages:
 - `tsconfig` - shared tsconfig for the entire project
 - `ui` - function to merge your Tailwind config with the global one; you can save components here
 - `vite-config` - shared Vite config for the entire project
-- `zipper` - run `pnpm zip` to pack the `dist` folder into `extension.zip` inside the newly created `dist-zip`
+- `zipper` - run `pnpm zip` to pack the `dist` folder into `extension-YYYYMMDD-HHmmss.zip` inside the newly created `dist-zip`
 - `e2e` - run `pnpm e2e` for end-to-end tests of your zipped extension on different browsers
 
 ## Troubleshooting

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "type": "module",
   "scripts": {
-    "clean:bundle": "rimraf dist && rimraf dist-zip && turbo clean:bundle",
+    "clean:bundle": "rimraf dist && turbo clean:bundle",
     "clean:node_modules": "turbo daemon stop && pnpx rimraf node_modules && pnpx turbo clean:node_modules",
     "clean:turbo": "turbo daemon stop && rimraf .turbo && turbo clean:turbo",
     "clean": "pnpm clean:bundle && pnpm clean:turbo && pnpm clean:node_modules",

--- a/packages/zipper/index.ts
+++ b/packages/zipper/index.ts
@@ -1,9 +1,13 @@
 import { resolve } from 'node:path';
 import { zipBundle } from './lib/zip-bundle';
 
+const YYYYMMDD = new Date().toISOString().slice(0, 10).replace(/-/g, '');
+const HHmmss = new Date().toISOString().slice(11, 19).replace(/:/g, '');
+const fileName = `extension-${YYYYMMDD}-${HHmmss}`;
+
 // package the root dist file
 zipBundle({
   distDirectory: resolve(__dirname, '../../dist'),
   buildDirectory: resolve(__dirname, '../../dist-zip'),
-  archiveName: process.env.__FIREFOX__ ? 'extension.xpi' : 'extension.zip',
+  archiveName: process.env.__FIREFOX__ ? `${fileName}.xpi` : `${fileName}.zip`,
 });

--- a/tests/e2e/config/wdio.browser.conf.ts
+++ b/tests/e2e/config/wdio.browser.conf.ts
@@ -6,10 +6,14 @@ import { getChromeExtensionPath, getFirefoxExtensionPath } from '../utils/extens
 
 const isFirefox = process.env.__FIREFOX__ === 'true';
 const isCI = process.env.CI === 'true';
-
-const archiveName = isFirefox ? 'extension.xpi' : 'extension.zip';
+const extName = isFirefox ? '.xpi' : '.zip';
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url));
-const extPath = path.join(__dirname, `../../../dist-zip/${archiveName}`);
+const extensions = await fs.readdir(path.join(__dirname, '../../../dist-zip'));
+const latestExtension = extensions
+  .filter(file => path.extname(file) === extName)
+  .sort()
+  .reverse()[0];
+const extPath = path.join(__dirname, `../../../dist-zip/${latestExtension}`);
 const bundledExtension = (await fs.readFile(extPath)).toString('base64');
 
 const chromeCapabilities = {


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

Inspired by #805, When `pnpm zip` runs, it excludes the `dist-zip` folder from the clean target to leave the existing zip version, and reveals the time of the compression in the filename.

## Changes*

1. exclude dist-zip from clean:bundle.
2. specify compression time in compressed filename.
3. update README.md

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->


## Reference
<!-- Any helpful information for understanding the PR. -->
