### PR TITLE
chore: enable emptyOutDir for all Vite config files, optimize extension size

### DIFF
--- a/chrome-extension/vite.config.mts
+++ b/chrome-extension/vite.config.mts
@@ -34,7 +34,7 @@ export default defineConfig({
       fileName: 'background',
     },
     outDir,
-    emptyOutDir: true,
+    emptyOutDir: false,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/chrome-extension/vite.config.mts
+++ b/chrome-extension/vite.config.mts
@@ -34,7 +34,7 @@ export default defineConfig({
       fileName: 'background',
     },
     outDir,
-    emptyOutDir: false,
+    emptyOutDir: true,
     sourcemap: isDev,
     minify: isProduction,
     reportCompressedSize: isProduction,

--- a/pages/content-runtime/vite.config.mts
+++ b/pages/content-runtime/vite.config.mts
@@ -19,5 +19,6 @@ export default withPageConfig({
       fileName: 'index',
     },
     outDir: resolve(rootDir, '..', '..', 'dist', 'content-runtime'),
+    emptyOutDir: true,
   },
 });

--- a/pages/content-ui/vite.config.mts
+++ b/pages/content-ui/vite.config.mts
@@ -21,5 +21,6 @@ export default withPageConfig({
       fileName: 'index',
     },
     outDir: resolve(rootDir, '..', '..', 'dist', 'content-ui'),
+    emptyOutDir: true,
   },
 });

--- a/pages/content/vite.config.mts
+++ b/pages/content/vite.config.mts
@@ -21,5 +21,6 @@ export default withPageConfig({
       fileName: 'index',
     },
     outDir: resolve(rootDir, '..', '..', 'dist', 'content'),
+    emptyOutDir: true,
   },
 });

--- a/pages/devtools-panel/vite.config.mts
+++ b/pages/devtools-panel/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'devtools-panel'),
+    emptyOutDir: true,
   },
 });

--- a/pages/devtools/vite.config.mts
+++ b/pages/devtools/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'devtools'),
+    emptyOutDir: true,
   },
 });

--- a/pages/new-tab/vite.config.mts
+++ b/pages/new-tab/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'new-tab'),
+    emptyOutDir: true,
   },
 });

--- a/pages/options/vite.config.mts
+++ b/pages/options/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'options'),
+    emptyOutDir: true,
   },
 });

--- a/pages/popup/vite.config.mts
+++ b/pages/popup/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'popup'),
+    emptyOutDir: true,
   },
 });

--- a/pages/side-panel/vite.config.mts
+++ b/pages/side-panel/vite.config.mts
@@ -13,5 +13,6 @@ export default withPageConfig({
   publicDir: resolve(rootDir, 'public'),
   build: {
     outDir: resolve(rootDir, '..', '..', 'dist', 'side-panel'),
+    emptyOutDir: true,
   },
 });


### PR DESCRIPTION
# chore: enable emptyOutDir for all Vite config files, optimize extension size

**Description**  
This PR enables the `emptyOutDir` option in all Vite configuration files and optimizes the build settings to reduce the extension size. With this change, each build process will clean the output directory before generating new files, helping to avoid potential conflicts or stale artifacts and reducing the final extension size.

---

## Priority

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

---

## Purpose of the PR

- Enable the `emptyOutDir: true` option in all Vite-based build environments.  
- Ensure a clean output folder for generated artifacts to prevent stale files.  
- Optimize extension size.

---

## Changes

1. **pages/content-runtime/vite.config.mts**  
   - Added `emptyOutDir: true`.

2. **pages/content-ui/vite.config.mts**  
   - Added `emptyOutDir: true`.

3. **pages/content/vite.config.mts**  
   - Added `emptyOutDir: true`.

4. **pages/devtools-panel/vite.config.mts**  
   - Added `emptyOutDir: true`.

5. **pages/devtools/vite.config.mts**  
   - Added `emptyOutDir: true`.

6. **pages/new-tab/vite.config.mts**  
   - Added `emptyOutDir: true`.

7. **pages/options/vite.config.mts**  
   - Added `emptyOutDir: true`.

8. **pages/popup/vite.config.mts**  
   - Added `emptyOutDir: true`.

9. **pages/side-panel/vite.config.mts**  
    - Added `emptyOutDir: true`.

In total, 9 configuration files were updated to ensure that each build process generates a clean output directory and helps reduce the final extension size.

---

## How to Test the Feature

1. Run the build for each project (e.g., `pnpm run build` or `npm run build`, depending on your setup).  
2. Check the `dist` folder (or your configured output directory) to confirm that previous contents are removed before generating new files.  
3. Verify whether the extension size is reduced or remains as expected.  
4. Test each generated artifact to ensure that the extension and its various pages function correctly without leftover files.

---

## Reference

- [Vite Build Options](https://vitejs.dev/config/build-options.html#build-emptyoutdir)

If you have any questions or need more information, feel free to comment here. Thanks!
