### PR TITLE
Fix: theme toggle each time content script is loaded

### DIFF
--- a/pages/content/package.json
+++ b/pages/content/package.json
@@ -19,8 +19,7 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
-    "@extension/shared": "workspace:*",
-    "@extension/storage": "workspace:*"
+    "@extension/shared": "workspace:*"
   },
   "devDependencies": {
     "@extension/hmr": "workspace:*",

--- a/pages/content/src/index.ts
+++ b/pages/content/src/index.ts
@@ -1,5 +1,6 @@
-import { toggleTheme } from '@src/toggleTheme';
+import { sampleFunction } from '@src/sampleFunction';
 
 console.log('content script loaded');
 
-void toggleTheme();
+// Shows how to call a function defined in another module
+sampleFunction();

--- a/pages/content/src/sampleFunction.ts
+++ b/pages/content/src/sampleFunction.ts
@@ -1,0 +1,3 @@
+export function sampleFunction() {
+  console.log('content script - sampleFunction() called from another module');
+}

--- a/pages/content/src/toggleTheme.ts
+++ b/pages/content/src/toggleTheme.ts
@@ -1,7 +1,0 @@
-import { exampleThemeStorage } from '@extension/storage';
-
-export async function toggleTheme() {
-  console.log('initial theme:', await exampleThemeStorage.get());
-  await exampleThemeStorage.toggle();
-  console.log('toggled theme:', await exampleThemeStorage.get());
-}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -282,9 +282,6 @@ importers:
       '@extension/shared':
         specifier: workspace:*
         version: link:../../packages/shared
-      '@extension/storage':
-        specifier: workspace:*
-        version: link:../../packages/storage
     devDependencies:
       '@extension/hmr':
         specifier: workspace:*
@@ -5457,7 +5454,7 @@ snapshots:
 
   '@wdio/globals@9.4.5(@wdio/logger@9.4.4)':
     optionalDependencies:
-      expect-webdriverio: 5.0.2(@wdio/globals@9.4.5(@wdio/logger@9.1.0))(@wdio/logger@9.4.4)(webdriverio@9.4.5)
+      expect-webdriverio: 5.0.2(@wdio/globals@9.4.5(@wdio/logger@9.4.4))(@wdio/logger@9.4.4)(webdriverio@9.4.5)
       webdriverio: 9.4.5
     transitivePeerDependencies:
       - '@wdio/logger'
@@ -6922,10 +6919,10 @@ snapshots:
       webdriverio: 9.4.5
     optional: true
 
-  expect-webdriverio@5.0.2(@wdio/globals@9.4.5(@wdio/logger@9.1.0))(@wdio/logger@9.4.4)(webdriverio@9.4.5):
+  expect-webdriverio@5.0.2(@wdio/globals@9.4.5(@wdio/logger@9.4.4))(@wdio/logger@9.4.4)(webdriverio@9.4.5):
     dependencies:
       '@vitest/snapshot': 2.0.5
-      '@wdio/globals': 9.4.5(@wdio/logger@9.1.0)
+      '@wdio/globals': 9.4.5(@wdio/logger@9.4.4)
       '@wdio/logger': 9.4.4
       expect: 29.7.0
       jest-matcher-utils: 29.7.0


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->

Make sure the theme doesn't change every time the content script is loaded into a page. This can be a bit confusing the first time you test the project.

## Changes*

I removed the `toggleTheme()` function in the content script and the dependency in `package.json`. I added an external function to still show an example of how to define functions in an external module.


## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

Open the extension's side panel and then search in the browser's search bar. The theme no longer changes every time you change pages (when the content script is loaded).



