### PR TITLE
fix: Vite Rollup error about resolving import with alias

### DIFF
--- a/packages/ui/lib/components/Button.tsx
+++ b/packages/ui/lib/components/Button.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef } from 'react';
-import { cn } from '@/lib/utils';
+import { cn } from '../utils';
 
 export type ButtonProps = {
   theme?: 'light' | 'dark';

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -3,10 +3,7 @@
   "compilerOptions": {
     "outDir": "dist",
     "baseUrl": ".",
-    "types": ["chrome"],
-    "paths": {
-      "@/*": ["./*"]
-    },
+    "types": ["chrome", "node"],
     "noEmit": false
   },
   "include": ["index.ts", "lib"]


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Fix ENOENT error about resolve import "@/lib/utils" 

## Changes*
I've remove alias from `tsconfig` and change import to relative in `Button.tsx`

## How to check the feature
Run `pnpm dev` or `pnpm build`

## Reference
![Zrzut ekranu 2025-01-25 195116](https://github.com/user-attachments/assets/9b448b9a-a12d-4ab2-9fbf-344de9bb6b4e)

