### PR TITLE
feat: unify popup and content-ui toggle buttons

### DIFF
--- a/packages/ui/lib/components/Button.tsx
+++ b/packages/ui/lib/components/Button.tsx
@@ -1,11 +1,13 @@
 import type { ComponentPropsWithoutRef } from 'react';
 import { cn } from '../utils';
+import { useStorage } from '@extension/shared';
+import { exampleThemeStorage } from '@extension/storage';
 
-export type ButtonProps = {
-  theme?: 'light' | 'dark';
-} & ComponentPropsWithoutRef<'button'>;
+export type ButtonProps = ComponentPropsWithoutRef<'button'>;
 
-export function Button({ theme, className, children, ...props }: ButtonProps) {
+export const Button = ({ className, children, ...props }: ButtonProps) => {
+  const theme = useStorage(exampleThemeStorage);
+
   return (
     <button
       className={cn(
@@ -17,4 +19,4 @@ export function Button({ theme, className, children, ...props }: ButtonProps) {
       {children}
     </button>
   );
-}
+};

--- a/packages/ui/lib/components/ToggleButton.tsx
+++ b/packages/ui/lib/components/ToggleButton.tsx
@@ -1,0 +1,13 @@
+import type { ButtonProps } from './Button';
+import { Button } from './Button';
+import { exampleThemeStorage } from '@extension/storage';
+
+type ToggleButtonProps = ButtonProps;
+
+export const ToggleButton = ({ className, children, ...props }: ToggleButtonProps) => {
+  return (
+    <Button className={className + 'font-bold mt-4'} onClick={exampleThemeStorage.toggle} {...props}>
+      {children}
+    </Button>
+  );
+};

--- a/packages/ui/lib/components/index.ts
+++ b/packages/ui/lib/components/index.ts
@@ -1,1 +1,2 @@
 export * from './Button';
+export * from './ToggleButton';

--- a/packages/ui/lib/index.ts
+++ b/packages/ui/lib/index.ts
@@ -1,3 +1,3 @@
-export * from './components/index';
+export * from './components';
 export * from './utils';
 export * from './withUI';

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -23,6 +23,8 @@
     "type-check": "tsc --noEmit"
   },
   "dependencies": {
+    "@extension/storage": "workspace:*",
+    "@extension/shared": "workspace:*",
     "clsx": "^2.1.1",
     "tailwind-merge": "^2.4.0"
   },

--- a/pages/content-ui/package.json
+++ b/pages/content-ui/package.json
@@ -25,7 +25,8 @@
     "@extension/env": "workspace:*",
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
-    "@extension/ui": "workspace:*"
+    "@extension/ui": "workspace:*",
+    "@extension/i18n": "workspace:*"
   },
   "devDependencies": {
     "@extension/hmr": "workspace:*",

--- a/pages/content-ui/src/App.tsx
+++ b/pages/content-ui/src/App.tsx
@@ -1,11 +1,9 @@
 import { useEffect } from 'react';
-import { Button } from '@extension/ui';
-import { useStorage } from '@extension/shared';
+import { ToggleButton } from '@extension/ui';
 import { exampleThemeStorage } from '@extension/storage';
+import { t } from '@extension/i18n';
 
 export default function App() {
-  const theme = useStorage(exampleThemeStorage);
-
   useEffect(() => {
     console.log('content ui loaded');
   }, []);
@@ -15,9 +13,7 @@ export default function App() {
       <div className="flex gap-1 text-blue-500">
         Edit <strong className="text-blue-700">pages/content-ui/src/app.tsx</strong> and save to reload.
       </div>
-      <Button theme={theme} onClick={exampleThemeStorage.toggle}>
-        Toggle Theme
-      </Button>
+      <ToggleButton onClick={exampleThemeStorage.toggle}>{t('toggleTheme')}</ToggleButton>
     </div>
   );
 }

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -1,9 +1,8 @@
 import '@src/Popup.css';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
-import type { ComponentPropsWithoutRef } from 'react';
 import { t } from '@extension/i18n';
-import { Button } from '@extension/ui';
+import { ToggleButton } from '@extension/ui';
 
 const notificationOptions = {
   type: 'basic',
@@ -56,25 +55,11 @@ const Popup = () => {
           onClick={injectContentScript}>
           Click to inject Content Script
         </button>
-        <ToggleButton>{t('toggleTheme')}</ToggleButton>
+        <ToggleButton className={`border-2 ${theme === 'light' ? 'border-black' : 'border-white'}`}>
+          {t('toggleTheme')}
+        </ToggleButton>
       </header>
     </div>
-  );
-};
-
-const ToggleButton = (props: ComponentPropsWithoutRef<'button'>) => {
-  const theme = useStorage(exampleThemeStorage);
-  return (
-    <Button
-      className={
-        props.className +
-        ' ' +
-        'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ' +
-        (theme === 'light' ? 'bg-white text-black shadow-black' : 'bg-black text-white')
-      }
-      onClick={exampleThemeStorage.toggle}>
-      {props.children}
-    </Button>
   );
 };
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -217,6 +217,12 @@ importers:
 
   packages/ui:
     dependencies:
+      '@extension/shared':
+        specifier: workspace:*
+        version: link:../shared
+      '@extension/storage':
+        specifier: workspace:*
+        version: link:../storage
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
@@ -295,6 +301,9 @@ importers:
       '@extension/env':
         specifier: workspace:*
         version: link:../../packages/env
+      '@extension/i18n':
+        specifier: workspace:*
+        version: link:../../packages/i18n
       '@extension/shared':
         specifier: workspace:*
         version: link:../../packages/shared


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to unify this 2 buttons, because it's strange to toggle theme in e.g `popup` and it doesn't affect `content-ui` button as well

## Changes*
I've create `ToggleButton` which basing on `Button` from `ui` package and use translation for both

## How to check the feature
Run `pnpm dev` or other and check if it works