### PR TITLE
Fix: Ensure the output directory exists when the public directory is deliberately omitted

### DIFF
--- a/packages/hmr/lib/plugins/make-entry-point-plugin.ts
+++ b/packages/hmr/lib/plugins/make-entry-point-plugin.ts
@@ -18,6 +18,11 @@ export function makeEntryPointPlugin(): PluginOption {
         throw new Error('Output directory not found');
       }
 
+      // Ensure the output directory exists.
+      if (!fs.existsSync(outputDir)) {
+        fs.mkdirSync(outputDir, { recursive: true });
+      }
+
       for (const module of Object.values(bundle)) {
         const fileName = path.basename(module.fileName);
         const newFileName = fileName.replace('.js', '_dev.js');


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
Ensure the ability to delete `public` directories in projects located within the `pages` directory.
To explain the problem in detail: when the `public` directory is created, `Vite` prioritizes managing this directory and therefore creates the folder structure needed for the build before calling the `generateBundle()` function within the `makeEntryPointPlugin()` plugin. The issue is that when the `public` directory doesn't exist, the folder structure isn't created, and this plugin requires an existing directory structure to write to files.

## Changes*
Creating the required folder structure within the `makeEntryPointPlugin()` plugin if it doesn't exist.

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->
Delete the `public` directory within a project, such as `content-ui`, run `npm run dev`, and check that there are no errors in the console for the tested project.

## Reference
<!-- Any helpful information for understanding the PR. -->
