### PR TITLE
feat: change all packages to be `module`

### DIFF
--- a/packages/shared/index.mts
+++ b/packages/shared/index.mts
@@ -1,0 +1,3 @@
+export * from './lib/hooks/index.js';
+export * from './lib/hoc/index.js';
+export * from './lib/utils/index.js';

--- a/packages/shared/index.ts
+++ b/packages/shared/index.ts
@@ -1,3 +1,0 @@
-export * from './lib/hooks';
-export * from './lib/hoc';
-export * from './lib/utils';

--- a/packages/shared/lib/hoc/index.ts
+++ b/packages/shared/lib/hoc/index.ts
@@ -1,2 +1,2 @@
-export { withSuspense } from './withSuspense';
-export { withErrorBoundary } from './withErrorBoundary';
+export { withSuspense } from './withSuspense.js';
+export { withErrorBoundary } from './withErrorBoundary.js';

--- a/packages/shared/lib/hooks/index.ts
+++ b/packages/shared/lib/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './useStorage';
+export * from './useStorage.js';

--- a/packages/shared/lib/utils/index.ts
+++ b/packages/shared/lib/utils/index.ts
@@ -1,1 +1,1 @@
-export * from './shared-types';
+export * from './shared-types.js';

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -8,8 +8,8 @@
   "files": [
     "dist/**"
   ],
-  "types": "index.ts",
-  "main": "dist/index.js",
+  "types": "index.mts",
+  "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
     "clean:node_modules": "pnpx rimraf node_modules",

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "@extension/tsconfig/base",
+  "extends": "@extension/tsconfig/module",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist",
-    "noEmit": false
+    "outDir": "dist"
   },
-  "include": ["index.ts", "lib"]
+  "include": ["index.mts", "lib"]
 }

--- a/packages/storage/index.mts
+++ b/packages/storage/index.mts
@@ -1,0 +1,1 @@
+export * from './lib/index.js';

--- a/packages/storage/index.ts
+++ b/packages/storage/index.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -1,5 +1,5 @@
-import type { BaseStorage, StorageConfig, ValueOrUpdate } from './types';
-import { SessionAccessLevelEnum, StorageEnum } from './enums';
+import type { BaseStorage, StorageConfig, ValueOrUpdate } from './types.js';
+import { SessionAccessLevelEnum, StorageEnum } from './enums.js';
 
 /**
  * Chrome reference error while running `processTailwindFeatures` in tailwindcss.

--- a/packages/storage/lib/base/index.ts
+++ b/packages/storage/lib/base/index.ts
@@ -1,3 +1,3 @@
-export * from './base';
-export * from './enums';
-export * from './types';
+export * from './base.js';
+export * from './enums.js';
+export * from './types.js';

--- a/packages/storage/lib/base/types.ts
+++ b/packages/storage/lib/base/types.ts
@@ -1,4 +1,4 @@
-import type { StorageEnum } from './enums';
+import type { StorageEnum } from './enums.js';
 
 export type ValueOrUpdate<D> = D | ((prev: D) => Promise<D> | D);
 

--- a/packages/storage/lib/impl/exampleThemeStorage.ts
+++ b/packages/storage/lib/impl/exampleThemeStorage.ts
@@ -1,5 +1,5 @@
-import type { BaseStorage } from '../base';
-import { StorageEnum, createStorage } from '../base';
+import type { BaseStorage } from '../base/index.js';
+import { createStorage, StorageEnum } from '../base/index.js';
 
 type Theme = 'light' | 'dark';
 

--- a/packages/storage/lib/impl/index.ts
+++ b/packages/storage/lib/impl/index.ts
@@ -1,1 +1,1 @@
-export * from './exampleThemeStorage';
+export * from './exampleThemeStorage.js';

--- a/packages/storage/lib/index.ts
+++ b/packages/storage/lib/index.ts
@@ -1,2 +1,2 @@
-export type { BaseStorage } from './base';
-export * from './impl';
+export type { BaseStorage } from './base/index.js';
+export * from './impl/index.js';

--- a/packages/storage/package.json
+++ b/packages/storage/package.json
@@ -8,8 +8,8 @@
   "files": [
     "dist/**"
   ],
-  "types": "index.ts",
-  "main": "dist/index.js",
+  "types": "index.mts",
+  "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
     "clean:node_modules": "pnpx rimraf node_modules",

--- a/packages/storage/tsconfig.json
+++ b/packages/storage/tsconfig.json
@@ -1,9 +1,8 @@
 {
-  "extends": "@extension/tsconfig/base",
+  "extends": "@extension/tsconfig/module",
   "compilerOptions": {
     "baseUrl": ".",
-    "outDir": "dist",
-    "noEmit": false
+    "outDir": "dist"
   },
-  "include": ["index.ts", "lib"]
+  "include": ["index.mts", "lib"]
 }

--- a/packages/ui/README.md
+++ b/packages/ui/README.md
@@ -49,14 +49,14 @@ import '@extension/ui/lib/global.css';
 Add the following to the `lib/components/index.ts` file.
 
 ```tsx
-export * from './CustomComponent';
+export * from './CustomComponent.js';
 ```
 
 Add the following to the `lib/components/CustomComponent.tsx` file.
 
 ```tsx
 import { ComponentPropsWithoutRef } from 'react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils.js';
 
 type CustomComponentProps = ComponentPropsWithoutRef<'section'>;
 
@@ -133,7 +133,8 @@ pnpm add tailwindcss-animate class-variance-authority tailwind-merge lucide-reac
 
 3. Edit `withUI.ts` in `lib` folder
 
-This configuration file is from the manual guide. You can refer to the manual guide to modify the configuration file. ([`Configure tailwind.config.js`](https://ui.shadcn.com/docs/installation/manual))
+This configuration file is from the manual guide. You can refer to the manual guide to modify the configuration file. ([
+`Configure tailwind.config.js`](https://ui.shadcn.com/docs/installation/manual))
 
 ```ts
 import deepmerge from 'deepmerge';
@@ -226,7 +227,8 @@ const shadcnConfig = {
 
 4. Edit `global.css` in `lib` folder
 
-This configuration also comes from the manual guide. You can refer to the manual guide to modify the configuration file. ([`Configure styles`](https://ui.shadcn.com/docs/installation/manual))
+This configuration also comes from the manual guide. You can refer to the manual guide to modify the configuration
+file. ([`Configure styles`](https://ui.shadcn.com/docs/installation/manual))
 
 ```css
 @tailwind base;
@@ -284,6 +286,7 @@ This configuration also comes from the manual guide. You can refer to the manual
     * {
         @apply border-border;
     }
+
     body {
         @apply font-sans antialiased bg-background text-foreground;
     }
@@ -304,9 +307,9 @@ Remember to adjust any paths or package names if your project structure differs 
 
 6. Export components
 
-Edit the `index.ts` file in the `packages/ui` directory to export the shadcn ui component:
+Edit the `index.mts` file in the `packages/ui` directory to export the shadcn ui component:
 
 ```ts
 //...
-export * from './lib/components/ui/button';
+export * from './lib/components/ui/button.js';
 ```

--- a/packages/ui/index.mts
+++ b/packages/ui/index.mts
@@ -1,0 +1,1 @@
+export * from './lib/index.js';

--- a/packages/ui/index.ts
+++ b/packages/ui/index.ts
@@ -1,1 +1,0 @@
-export * from './lib';

--- a/packages/ui/lib/components/ToggleButton.tsx
+++ b/packages/ui/lib/components/ToggleButton.tsx
@@ -1,7 +1,7 @@
 import { exampleThemeStorage } from '@extension/storage';
 import { useStorage } from '@extension/shared';
 import type { ComponentPropsWithoutRef } from 'react';
-import { cn } from '@/lib/utils';
+import { cn } from '@/lib/utils.js';
 
 type ToggleButtonProps = ComponentPropsWithoutRef<'button'>;
 

--- a/packages/ui/lib/components/index.ts
+++ b/packages/ui/lib/components/index.ts
@@ -1,1 +1,1 @@
-export * from './ToggleButton';
+export * from './ToggleButton.js';

--- a/packages/ui/lib/index.ts
+++ b/packages/ui/lib/index.ts
@@ -1,3 +1,3 @@
-export * from './components';
-export * from './utils';
-export * from './withUI';
+export * from './components/index.js';
+export * from './utils.js';
+export * from './withUI.js';

--- a/packages/ui/lib/withUI.ts
+++ b/packages/ui/lib/withUI.ts
@@ -1,5 +1,5 @@
 import deepmerge from 'deepmerge';
-import type { Config } from 'tailwindcss/types/config';
+import type { Config } from 'tailwindcss/types/config.js';
 
 export function withUI(tailwindConfig: Config): Config {
   return deepmerge(tailwindConfig, {

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -9,8 +9,8 @@
     "dist/**",
     "dist/global.css"
   ],
-  "types": "index.ts",
-  "main": "./dist/index.js",
+  "types": "index.mts",
+  "main": "dist/index.mjs",
   "scripts": {
     "clean:bundle": "rimraf dist",
     "clean:node_modules": "pnpx rimraf node_modules",

--- a/packages/ui/tsconfig.json
+++ b/packages/ui/tsconfig.json
@@ -1,13 +1,11 @@
 {
-  "extends": "@extension/tsconfig/base",
+  "extends": "@extension/tsconfig/module",
   "compilerOptions": {
     "outDir": "dist",
     "baseUrl": ".",
-    "types": ["chrome", "node"],
-    "noEmit": false,
     "paths": {
       "@/*": ["./*"]
     }
   },
-  "include": ["index.ts", "lib"]
+  "include": ["index.mts", "lib"]
 }


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I need to change rest packages to be `module` because it isn't possible to import package(Look on screenshot) which extends `base` tsconfig, because of conflict in `target`, `module`, `moduleResolution` 

## Changes*
I've change extends from `base` to `module` for packages which wasn't had it already and adjust code.

## How to check the feature
Run `pnpm dev` and check if everything work fine

## Reference
![image](https://github.com/user-attachments/assets/f704a332-3cac-497e-b4ca-132814f6dfb6)
