### PR TITLE
fix: disable `cache` for turbo `ready` task

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -6,7 +6,8 @@
   "tasks": {
     "ready": {
       "dependsOn": ["^ready"],
-      "outputs": ["dist/**", "build/**"]
+      "outputs": ["dist/**", "build/**"],
+      "cache": false
     },
     "dev": {
       "dependsOn": ["ready"],


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Description in #860