### PR TITLE
Ensure valid manifest for Firefox when background or options are not present

### DIFF
--- a/packages/dev-utils/lib/manifest-parser/impl.ts
+++ b/packages/dev-utils/lib/manifest-parser/impl.ts
@@ -14,14 +14,18 @@ function convertToFirefoxCompatibleManifest(manifest: Manifest) {
     ...manifest,
   } as { [key: string]: unknown };
 
-  manifestCopy.background = {
-    scripts: [manifest.background?.service_worker],
-    type: 'module',
-  };
-  manifestCopy.options_ui = {
-    page: manifest.options_page,
-    browser_style: false,
-  };
+  if (manifest.background?.service_worker) {
+    manifestCopy.background = {
+      scripts: [manifest.background?.service_worker],
+      type: 'module',
+    };
+  }
+  if (manifest.options_page) {
+    manifestCopy.options_ui = {
+      page: manifest.options_page,
+      browser_style: false,
+    };
+  }
   manifestCopy.content_security_policy = {
     extension_pages: "script-src 'self'; object-src 'self'",
   };

--- a/packages/dev-utils/lib/manifest-parser/impl.ts
+++ b/packages/dev-utils/lib/manifest-parser/impl.ts
@@ -16,7 +16,7 @@ function convertToFirefoxCompatibleManifest(manifest: Manifest) {
 
   if (manifest.background?.service_worker) {
     manifestCopy.background = {
-      scripts: [manifest.background?.service_worker],
+      scripts: [manifest.background.service_worker],
       type: 'module',
     };
   }


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Improve handling for making compatible manifest for Firefox when Background Scripts or Options UI are not used in manifest.js 

## Changes*
Add if checks to ensure correct manifest.json for Firefox when `manifest.background?.service_worker` or `manifest.options_page` are undefined

## How to check the feature
1. Comment or remove `options_page` or `background` in `manifest.js`.
2. Run `pnpm build:firefox`
3. The resultant `dist/manifest.json` will be valid now, which was not the case before