### PR TITLE
fix(module-manager): read archive files if exists

### DIFF
--- a/packages/module-manager/lib/recoverModules.ts
+++ b/packages/module-manager/lib/recoverModules.ts
@@ -6,7 +6,7 @@ import { checkbox } from '@inquirer/prompts';
 const pagesPath = path.resolve(import.meta.dirname, '..', '..', '..', 'pages');
 const archivePath = path.resolve(import.meta.dirname, '..', 'archive');
 
-const archiveFiles = fs.readdirSync(archivePath);
+const archiveFiles = fs.existsSync(archivePath) ? fs.readdirSync(archivePath) : [];
 
 const DEFAULT_CHOICES = [
   { name: 'Background Script', value: 'background' },


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
The `module-manager` tries to read archive files, but the `archive` dir does not exist in the initial call. 

## Changes*
I changed the `archiveFiles` reader statement to a ternary instead of creating the dir itself since the `deleteModules` already handles dir creation.

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->
1. Delete `packages/module-manager/archive` dir if it exists
2. Run `pnpm module-manager`

## Reference
<!-- Any helpful information for understanding the PR. -->
Error log:
```
Error: ENOENT: no such file or directory, scandir '{path}/chrome-extension-boilerplate-react-vite/packages/module-manager/archive'
    at Object.readdirSync (node:fs:1584:26)
    at <anonymous> ({path}/chrome-extension-boilerplate-react-vite/packages/module-manager/lib/recoverModules.ts:9:25)
    at ModuleJob.run (node:internal/modules/esm/module_job:271:25)
    at async onImport.tracePromise.__proto__ (node:internal/modules/esm/loader:578:26)
    at async asyncRunEntryPointWithESMLoader (node:internal/modules/run_main:116:5) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'scandir',
  path: '{path}/chrome-extension-boilerplate-react-vite/packages/module-manager/archive'
}
```
