### PR TITLE
fix: Handle string chunks in file streaming for zip operations

### DIFF
--- a/packages/module-manager/lib/deleteModules.ts
+++ b/packages/module-manager/lib/deleteModules.ts
@@ -218,7 +218,9 @@ function streamFileToZip(
   void zip.add(data);
 
   createReadStream(absPath)
-    .on('data', (chunk: Buffer) => data.push(chunk, false))
+    .on('data', (chunk: string | Buffer) =>
+      typeof chunk === 'string' ? data.push(Buffer.from(chunk), false) : data.push(chunk, false),
+    )
     .on('end', () => data.push(new Uint8Array(0), true))
     .on('error', error => {
       onAbort();

--- a/packages/zipper/lib/index.ts
+++ b/packages/zipper/lib/index.ts
@@ -32,7 +32,9 @@ function streamFileToZip(
   zip.add(data);
 
   createReadStream(absPath)
-    .on('data', (chunk: Buffer) => data.push(chunk, false))
+    .on('data', (chunk: string | Buffer) =>
+      typeof chunk === 'string' ? data.push(Buffer.from(chunk), false) : data.push(chunk, false),
+    )
     .on('end', () => data.push(new Uint8Array(0), true))
     .on('error', error => {
       onAbort();


### PR DESCRIPTION
Support converting string chunks to Buffer when streaming files to zip, ensuring consistent data type handling across module-manager and zipper packages

<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
Trying to start the dev server and getting an error ❌

## Changes*

- `packages/module-manager/lib/deleteModules.ts`
-  `packages/zipper/lib/index.ts`

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->
```
pnpm install
pnpm dev
```

## Reference
<!-- Any helpful information for understanding the PR. -->

Run dev mode Error log:
```
│ lib/index.ts:35:17 - error TS2345: Argument of type '(chunk: Buffer) => void' is not ass
│ ignable to parameter of type '(chunk: string | Buffer<ArrayBufferLike>) => void'.
│   Types of parameters 'chunk' and 'chunk' are incompatible.
│     Type 'string | Buffer<ArrayBufferLike>' is not assignable to type 'Buffer<ArrayBuffe
│ rLike>'.
│       Type 'string' is not assignable to type 'Buffer<ArrayBufferLike>'.
│ 
│ 35     .on('data', (chunk: Buffer) => data.push(chunk, false))
│                    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
│ 
│ 
│ Found 1 error.
```
