### PR TITLE
fix: use `ValueOf` from `@extension/shared` instead of redefining

### DIFF
--- a/packages/dev-utils/lib/logger.ts
+++ b/packages/dev-utils/lib/logger.ts
@@ -1,4 +1,4 @@
-type ValueOf<T> = T[keyof T];
+import type { ValueOf } from '@extension/shared';
 
 type ColorType = 'success' | 'info' | 'error' | 'warning' | keyof typeof COLORS;
 

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -22,6 +22,7 @@
     "type-check": "tsc --noEmit"
   },
   "devDependencies": {
-    "@extension/tsconfig": "workspace:*"
+    "@extension/tsconfig": "workspace:*",
+    "@extension/shared": "workspace:*"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -178,6 +178,9 @@ importers:
 
   packages/dev-utils:
     devDependencies:
+      '@extension/shared':
+        specifier: workspace:*
+        version: link:../shared
       '@extension/tsconfig':
         specifier: workspace:*
         version: link:../tsconfig


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Use `ValueOf` from shared types instead of redefining it.