### PR TITLE
fix: add missing eslint --fix for lint-staged

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,8 @@
   },
   "lint-staged": {
     "*.{js,jsx,ts,tsx,json}": [
-      "prettier --write"
+      "prettier --write",
+      "eslint --fix"
     ]
   },
   "packageManager": "pnpm@9.15.1",


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I've wanted to run eslint with prettier like in GitHub actions, to create one more step of validation, to get know for dev, what's could be wrong with code, before he would decide to open a PR

## Changes*
I've added `eslint --fix` for `lint-staged` in package.json

## How to check the feature
Add sth to one of the files in project and then try to commit it.