### PR TITLE
Feat/change target branch for prs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,3 @@
 * @Jonghakseo
+
+default_branch = dev

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,1 @@
 * @Jonghakseo
-
-default_branch = dev

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,3 +1,5 @@
+<!-- Note: Please ensure your PR is targeting the `dev` branch -->
+
 <!-- Describe what this PR is for in the title. -->
 
 > `*` denotes required fields

--- a/.github/workflows/auto-change-prs-branch.yml
+++ b/.github/workflows/auto-change-prs-branch.yml
@@ -1,8 +1,8 @@
 name: Make sure new PRs are sent to development
 
 on:
-  pull_request_target:
-    types: [ opened, edited ]
+  pull_request:
+    types: [ opened ]
 
 jobs:
   check-branch:

--- a/.github/workflows/auto-change-prs-branch.yml
+++ b/.github/workflows/auto-change-prs-branch.yml
@@ -15,11 +15,11 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           target: main
-          exclude: development
-          change-to: development
+          exclude: dev
+          change-to: dev
           comment: |
             Your PR's base branch was set to `main`, PRs should be set to target `development`.
-            The base branch of this PR has been automatically changed to `development`, please check that there are no merge conflicts
+            The base branch of this PR has been automatically changed to `dev`, please check that there are no merge conflicts
           already-exists-action: close_other_continue
           already-exists-comment: "Closing {url} as it has the same base branch"
           already-exists-other-comment: "This PR was closed in favor of {url}"

--- a/.github/workflows/auto-change-prs-branch.yml
+++ b/.github/workflows/auto-change-prs-branch.yml
@@ -1,7 +1,7 @@
 name: Make sure new PRs are sent to development
 
 on:
-  pull_request:
+  pull_request_target:
     types: [ opened ]
 
 jobs:

--- a/.github/workflows/auto-change-prs-branch.yml
+++ b/.github/workflows/auto-change-prs-branch.yml
@@ -1,0 +1,25 @@
+name: Make sure new PRs are sent to development
+
+on:
+  pull_request_target:
+    types: [ opened, edited ]
+
+jobs:
+  check-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: Vankka/pr-target-branch-action@v3
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          target: main
+          exclude: development
+          change-to: development
+          comment: |
+            Your PR's base branch was set to `main`, PRs should be set to target `development`.
+            The base branch of this PR has been automatically changed to `development`, please check that there are no merge conflicts
+          already-exists-action: close_other_continue
+          already-exists-comment: "Closing {url} as it has the same base branch"
+          already-exists-other-comment: "This PR was closed in favor of {url}"


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to enforce our contributors to open PR's to `dev` branch, without changing default repo branch.

## Changes
I've use [PR Action](https://github.com/marketplace/actions/pull-request-target-branch-action) for our GH Actions workflow.

## How to check the feature
Try to open PR from e.g `feat/` branch to `main`