### PR TITLE
feat: prettify classNames in `pages` components

### DIFF
--- a/packages/storage/lib/impl/exampleThemeStorage.ts
+++ b/packages/storage/lib/impl/exampleThemeStorage.ts
@@ -1,23 +1,37 @@
 import { createStorage, StorageEnum } from '../base/index.js';
 import type { BaseStorage } from '../base/index.js';
 
-type Theme = 'light' | 'dark';
+interface ThemeState {
+  theme: 'light' | 'dark';
+  isLight: boolean;
+}
 
-type ThemeStorage = BaseStorage<Theme> & {
+type ThemeStorage = BaseStorage<ThemeState> & {
   toggle: () => Promise<void>;
 };
 
-const storage = createStorage<Theme>('theme-storage-key', 'light', {
-  storageEnum: StorageEnum.Local,
-  liveUpdate: true,
-});
+const storage = createStorage<ThemeState>(
+  'theme-storage-key',
+  {
+    theme: 'light',
+    isLight: true,
+  },
+  {
+    storageEnum: StorageEnum.Local,
+    liveUpdate: true,
+  },
+);
 
-// You can extend it with your own methods
 export const exampleThemeStorage: ThemeStorage = {
   ...storage,
   toggle: async () => {
-    await storage.set(currentTheme => {
-      return currentTheme === 'light' ? 'dark' : 'light';
+    await storage.set(currentState => {
+      const newTheme = currentState.theme === 'light' ? 'dark' : 'light';
+
+      return {
+        theme: newTheme,
+        isLight: newTheme === 'light',
+      };
     });
   },
 };

--- a/packages/ui/lib/components/ToggleButton.tsx
+++ b/packages/ui/lib/components/ToggleButton.tsx
@@ -6,15 +6,15 @@ import type { ComponentPropsWithoutRef } from 'react';
 type ToggleButtonProps = ComponentPropsWithoutRef<'button'>;
 
 export const ToggleButton = ({ className, children, ...props }: ToggleButtonProps) => {
-  const theme = useStorage(exampleThemeStorage);
+  const { isLight } = useStorage(exampleThemeStorage);
 
   return (
     <button
       className={cn(
         className,
         'py-1 px-4 rounded shadow hover:scale-105',
-        theme === 'light' ? 'bg-white text-black' : 'bg-black text-white',
-        theme === 'light' ? 'border-black' : 'border-white',
+        isLight ? 'bg-white text-black' : 'bg-black text-white',
+        isLight ? 'border-black' : 'border-white',
         'mt-4 border-2 font-bold',
       )}
       onClick={exampleThemeStorage.toggle}

--- a/pages/devtools-panel/package.json
+++ b/pages/devtools-panel/package.json
@@ -22,7 +22,8 @@
   "dependencies": {
     "@extension/shared": "workspace:*",
     "@extension/storage": "workspace:*",
-    "@extension/i18n": "workspace:*"
+    "@extension/i18n": "workspace:*",
+    "@extension/ui": "workspace:*"
   },
   "devDependencies": {
     "@extension/tailwindcss-config": "workspace:*",

--- a/pages/devtools-panel/src/Panel.tsx
+++ b/pages/devtools-panel/src/Panel.tsx
@@ -5,9 +5,9 @@ import { exampleThemeStorage } from '@extension/storage';
 import type { ComponentPropsWithoutRef } from 'react';
 
 const Panel = () => {
-  const theme = useStorage(exampleThemeStorage);
-  const isLight = theme === 'light';
+  const { isLight } = useStorage(exampleThemeStorage);
   const logo = isLight ? 'devtools-panel/logo_horizontal.svg' : 'devtools-panel/logo_horizontal_dark.svg';
+
   const goGithubSite = () =>
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 
@@ -27,14 +27,15 @@ const Panel = () => {
 };
 
 const ToggleButton = (props: ComponentPropsWithoutRef<'button'>) => {
-  const theme = useStorage(exampleThemeStorage);
+  const { isLight } = useStorage(exampleThemeStorage);
+
   return (
     <button
       className={
         props.className +
         ' ' +
         'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ' +
-        (theme === 'light' ? 'bg-white text-black' : 'bg-black text-white')
+        (isLight ? 'bg-white text-black' : 'bg-black text-white')
       }
       onClick={exampleThemeStorage.toggle}>
       {props.children}

--- a/pages/devtools-panel/src/Panel.tsx
+++ b/pages/devtools-panel/src/Panel.tsx
@@ -2,6 +2,7 @@ import '@src/Panel.css';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
+import { cn } from '@extension/ui';
 import type { ComponentPropsWithoutRef } from 'react';
 
 const Panel = () => {
@@ -12,8 +13,8 @@ const Panel = () => {
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 
   return (
-    <div className={`App ${isLight ? 'bg-slate-50' : 'bg-gray-800'}`}>
-      <header className={`App-header ${isLight ? 'text-gray-900' : 'text-gray-100'}`}>
+    <div className={cn('App', isLight ? 'bg-slate-50' : 'bg-gray-800')}>
+      <header className={cn('App-header', isLight ? 'text-gray-900' : 'text-gray-100')}>
         <button onClick={goGithubSite}>
           <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
         </button>
@@ -31,12 +32,11 @@ const ToggleButton = (props: ComponentPropsWithoutRef<'button'>) => {
 
   return (
     <button
-      className={
-        props.className +
-        ' ' +
-        'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ' +
-        (isLight ? 'bg-white text-black' : 'bg-black text-white')
-      }
+      className={cn(
+        props.className,
+        'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ',
+        isLight ? 'bg-white text-black' : 'bg-black text-white',
+      )}
       onClick={exampleThemeStorage.toggle}>
       {props.children}
     </button>

--- a/pages/new-tab/src/NewTab.tsx
+++ b/pages/new-tab/src/NewTab.tsx
@@ -6,9 +6,9 @@ import { exampleThemeStorage } from '@extension/storage';
 import { ToggleButton } from '@extension/ui';
 
 const NewTab = () => {
-  const theme = useStorage(exampleThemeStorage);
-  const isLight = theme === 'light';
+  const { isLight } = useStorage(exampleThemeStorage);
   const logo = isLight ? 'new-tab/logo_horizontal.svg' : 'new-tab/logo_horizontal_dark.svg';
+
   const goGithubSite = () =>
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 

--- a/pages/new-tab/src/NewTab.tsx
+++ b/pages/new-tab/src/NewTab.tsx
@@ -3,7 +3,7 @@ import '@src/NewTab.scss';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
-import { ToggleButton } from '@extension/ui';
+import { cn, ToggleButton } from '@extension/ui';
 
 const NewTab = () => {
   const { isLight } = useStorage(exampleThemeStorage);
@@ -14,8 +14,8 @@ const NewTab = () => {
 
   console.log(t('hello', 'World'));
   return (
-    <div className={`App ${isLight ? 'bg-slate-50' : 'bg-gray-800'}`}>
-      <header className={`App-header ${isLight ? 'text-gray-900' : 'text-gray-100'}`}>
+    <div className={cn('App', isLight ? 'bg-slate-50' : 'bg-gray-800')}>
+      <header className={cn('App-header', isLight ? 'text-gray-900' : 'text-gray-100')}>
         <button onClick={goGithubSite}>
           <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
         </button>

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -2,7 +2,7 @@ import '@src/Options.css';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
-import { ToggleButton } from '@extension/ui';
+import { cn, ToggleButton } from '@extension/ui';
 
 const Options = () => {
   const { isLight } = useStorage(exampleThemeStorage);
@@ -12,7 +12,7 @@ const Options = () => {
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 
   return (
-    <div className={`App ${isLight ? 'bg-slate-50 text-gray-900' : 'bg-gray-800 text-gray-100'}`}>
+    <div className={cn('App', isLight ? 'bg-slate-50 text-gray-900' : 'bg-gray-800 text-gray-100')}>
       <button onClick={goGithubSite}>
         <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
       </button>

--- a/pages/options/src/Options.tsx
+++ b/pages/options/src/Options.tsx
@@ -5,9 +5,9 @@ import { exampleThemeStorage } from '@extension/storage';
 import { ToggleButton } from '@extension/ui';
 
 const Options = () => {
-  const theme = useStorage(exampleThemeStorage);
-  const isLight = theme === 'light';
+  const { isLight } = useStorage(exampleThemeStorage);
   const logo = isLight ? 'options/logo_horizontal.svg' : 'options/logo_horizontal_dark.svg';
+
   const goGithubSite = () =>
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -12,9 +12,9 @@ const notificationOptions = {
 } as const;
 
 const Popup = () => {
-  const theme = useStorage(exampleThemeStorage);
-  const isLight = theme === 'light';
+  const { isLight } = useStorage(exampleThemeStorage);
   const logo = isLight ? 'popup/logo_vertical.svg' : 'popup/logo_vertical_dark.svg';
+
   const goGithubSite = () =>
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -2,7 +2,7 @@ import '@src/Popup.css';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
-import { ToggleButton } from '@extension/ui';
+import { cn, ToggleButton } from '@extension/ui';
 
 const notificationOptions = {
   type: 'basic',
@@ -39,8 +39,8 @@ const Popup = () => {
   };
 
   return (
-    <div className={`App ${isLight ? 'bg-slate-50' : 'bg-gray-800'}`}>
-      <header className={`App-header ${isLight ? 'text-gray-900' : 'text-gray-100'}`}>
+    <div className={cn('App', isLight ? 'bg-slate-50' : 'bg-gray-800')}>
+      <header className={cn('App-header', isLight ? 'text-gray-900' : 'text-gray-100')}>
         <button onClick={goGithubSite}>
           <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
         </button>
@@ -48,10 +48,10 @@ const Popup = () => {
           Edit <code>pages/popup/src/Popup.tsx</code>
         </p>
         <button
-          className={
-            'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ' +
-            (isLight ? 'bg-blue-200 text-black' : 'bg-gray-700 text-white')
-          }
+          className={cn(
+            'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ',
+            isLight ? 'bg-blue-200 text-black' : 'bg-gray-700 text-white',
+          )}
           onClick={injectContentScript}>
           Click to inject Content Script
         </button>

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -2,7 +2,7 @@ import '@src/SidePanel.css';
 import { t } from '@extension/i18n';
 import { useStorage, withErrorBoundary, withSuspense } from '@extension/shared';
 import { exampleThemeStorage } from '@extension/storage';
-import { ToggleButton } from '@extension/ui';
+import { cn, ToggleButton } from '@extension/ui';
 
 const SidePanel = () => {
   const { isLight } = useStorage(exampleThemeStorage);
@@ -12,8 +12,8 @@ const SidePanel = () => {
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 
   return (
-    <div className={`App ${isLight ? 'bg-slate-50' : 'bg-gray-800'}`}>
-      <header className={`App-header ${isLight ? 'text-gray-900' : 'text-gray-100'}`}>
+    <div className={cn('App', isLight ? 'bg-slate-50' : 'bg-gray-800')}>
+      <header className={cn('App-header', isLight ? 'text-gray-900' : 'text-gray-100')}>
         <button onClick={goGithubSite}>
           <img src={chrome.runtime.getURL(logo)} className="App-logo" alt="logo" />
         </button>

--- a/pages/side-panel/src/SidePanel.tsx
+++ b/pages/side-panel/src/SidePanel.tsx
@@ -5,9 +5,9 @@ import { exampleThemeStorage } from '@extension/storage';
 import { ToggleButton } from '@extension/ui';
 
 const SidePanel = () => {
-  const theme = useStorage(exampleThemeStorage);
-  const isLight = theme === 'light';
+  const { isLight } = useStorage(exampleThemeStorage);
   const logo = isLight ? 'side-panel/logo_vertical.svg' : 'side-panel/logo_vertical_dark.svg';
+
   const goGithubSite = () =>
     chrome.tabs.create({ url: 'https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite' });
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -405,6 +405,9 @@ importers:
       '@extension/storage':
         specifier: workspace:*
         version: link:../../packages/storage
+      '@extension/ui':
+        specifier: workspace:*
+        version: link:../../packages/ui
     devDependencies:
       '@extension/tailwindcss-config':
         specifier: workspace:*


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to prettify classNames and simplify checking current theme for classNames

## Changes*
I've changed exampleThemeStorage and use cn() for classNames of components

## How to check the feature
Run `pnpm build` or `pnpm dev` and check if everything works well