### PR TITLE
fix: add missing consistent-type-imports rule to eslint.config.ts

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -80,6 +80,7 @@ export default config(
       'import-x/consistent-type-specifier-style': 'error',
       'import-x/exports-last': 'error',
       'import-x/first': 'error',
+      '@typescript-eslint/consistent-type-imports': 'error',
     },
     linterOptions: {
       reportUnusedDisableDirectives: 'error',


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I've added missing rule for checking `type` imports on eslint.config `rules

## Changes*
I've added missing rule for `eslint.config.ts`

## How to check the feature
Run `pnpm lint` or `pnpm lint:fix`