### PR TITLE
fix/eslint-import-order

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,6 +55,7 @@ export default config(
       'prefer-const': 'error',
       'no-var': 'error',
       'func-style': ['error', 'expression', { allowArrowFunctions: true }],
+      '@typescript-eslint/consistent-type-imports': 'error',
       'import-x/order': [
         'error',
         {
@@ -63,12 +64,12 @@ export default config(
           groups: ['index', 'sibling', 'parent', 'internal', 'external', 'builtin', 'object', 'type'],
           pathGroups: [
             {
-              pattern: '@src/**',
+              pattern: '@*/**',
               group: 'internal',
               position: 'before',
             },
           ],
-          pathGroupsExcludedImportTypes: ['internal'],
+          pathGroupsExcludedImportTypes: ['type'],
         },
       ],
       'import-x/no-unresolved': 'off',
@@ -80,7 +81,6 @@ export default config(
       'import-x/consistent-type-specifier-style': 'error',
       'import-x/exports-last': 'error',
       'import-x/first': 'error',
-      '@typescript-eslint/consistent-type-imports': 'error',
     },
     linterOptions: {
       reportUnusedDisableDirectives: 'error',

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -56,6 +56,7 @@ export default config(
       'no-var': 'error',
       'func-style': ['error', 'expression', { allowArrowFunctions: true }],
       '@typescript-eslint/consistent-type-imports': 'error',
+      '@typescript-eslint/consistent-type-exports': 'error',
       'import-x/order': [
         'error',
         {


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I need to fix eslint conflict between rules for imports restriction

## Changes*
I've changed rules for `import-x/order`

## How to check the feature
Run `pnpm lint` or `pnpm lint:fix`