### PR TITLE
feat/configure restriction for importing `type-fest`

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -55,6 +55,13 @@ export default config(
       'prefer-const': 'error',
       'no-var': 'error',
       'func-style': ['error', 'expression', { allowArrowFunctions: true }],
+      'no-restricted-imports': [
+        'error',
+        {
+          name: 'type-fest',
+          message: 'Please import from `@extension/dev-utils` instead of `type-fest`.',
+        },
+      ],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/consistent-type-exports': 'error',
       'import-x/order': [


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to add checking imports against import `type-fest` from itself, for avoid redundant imports and import it from the place (`dev-utils`) where it was defined already 

## Changes*
I've configured no-restricted-imports for import `type-fest` values from `@extension/dev-utils` instead.  

## How to check the feature
- Try to import sth from `type-fest` from package other then `@extension/dev-utils`
- Run `pnpm lint` and check if error will occur