### PR TITLE
fix/add-eslint-import-checking

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -19,7 +19,7 @@ export default config(
   eslintPluginPrettierRecommended,
   ...fixupConfigRules(new FlatCompat().extends('plugin:react-hooks/recommended') as FixupConfigArray),
   {
-    files: ['**/*.{ts,tsx,mtsx}'],
+    files: ['**/*.{ts,tsx}'],
     ...reactPlugin.configs.flat.recommended,
     ...reactPlugin.configs.flat['jsx-runtime'],
   },
@@ -28,7 +28,7 @@ export default config(
     ignores: ['**/build/**', '**/dist/**', '**/node_modules/**', 'chrome-extension/manifest.js'],
   },
   {
-    files: ['**/*.{ts,tsx,mtsx}'],
+    files: ['**/*.{ts,tsx}'],
     languageOptions: {
       parser: tsParser,
       ecmaVersion: 'latest',
@@ -92,6 +92,13 @@ export default config(
     },
     linterOptions: {
       reportUnusedDisableDirectives: 'error',
+    },
+  },
+  // Overrides Rules
+  {
+    files: ['**/packages/dev-utils/**/*.ts'],
+    rules: {
+      'no-restricted-imports': 'off',
     },
   },
 );


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
Fix missing excluding for #944

## Changes*
I've exclude `type-fest` checking for `@extension/dev-utils`