### PR TITLE
fix/remove closing other actions on branch change(workflow)

### DIFF
--- a/.github/workflows/auto-change-prs-branch.yml
+++ b/.github/workflows/auto-change-prs-branch.yml
@@ -2,7 +2,7 @@ name: Make sure new PRs are sent to development
 
 on:
   pull_request_target:
-    types: [ opened ]
+    types: [ opened, ready_for_review ]
 
 jobs:
   check-branch:
@@ -20,6 +20,5 @@ jobs:
           comment: |
             Your PR's base branch was set to `main`, PRs should be set to target `dev`.
             The base branch of this PR has been automatically changed to `dev`, please check that there are no merge conflicts
-          already-exists-action: close_other_continue
           already-exists-comment: "Closing {url} as it has the same base branch"
           already-exists-other-comment: "This PR was closed in favor of {url}"


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
It fixes, finally right #946 

## Changes*
I've removed `already-exists-actions` from `auto-change-prs-branch.yml` (workflow)

## How to check the feature
Like on #946