### PR TITLE
fix: add onlyBuildDependencies for pnpm-workspace.yaml

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,5 +1,13 @@
 packages:
-  - 'chrome-extension'
-  - 'pages/*'
-  - 'packages/*'
-  - 'tests/*'
+  - chrome-extension
+  - pages/*
+  - packages/*
+  - tests/*
+
+onlyBuiltDependencies:
+  - '@parcel/watcher'
+  - '@swc/core'
+  - edgedriver
+  - esbuild
+  - geckodriver
+  - unrs-resolver


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
It need to be set because of requirements of pnpm 10

## Changes*
Added `onlyBuiltDependencies` with list of building packages to `pnpm-workspace.yaml` to fix warning on `pnpm i`

## How to check the feature
Run `pnpm i` and check if there's no error