### PR TITLE
feat/add-eslint-arrow-func-checking

### DIFF
--- a/chrome-extension/utils/plugins/make-manifest-plugin.ts
+++ b/chrome-extension/utils/plugins/make-manifest-plugin.ts
@@ -22,9 +22,7 @@ const refreshFilePath = resolve(
   'refresh.js',
 );
 
-const withHMRId = (code: string) => {
-  return `(function() {let __HMR_ID = 'chrome-extension-hmr';${code}\n})();`;
-};
+const withHMRId = (code: string) => `(function() {let __HMR_ID = 'chrome-extension-hmr';${code}\n})();`;
 
 const getManifestWithCacheBurst = async () => {
   const withCacheBurst = (path: string) => `${path}?${Date.now().toString()}`;

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -62,6 +62,7 @@ export default config(
           message: 'Please import from `@extension/shared` instead of `type-fest`.',
         },
       ],
+      'arrow-body-style': ['error', 'as-needed'],
       '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/consistent-type-exports': 'error',
       'import-x/order': [

--- a/packages/hmr/lib/plugins/watch-public-plugin.ts
+++ b/packages/hmr/lib/plugins/watch-public-plugin.ts
@@ -1,15 +1,13 @@
 import fg from 'fast-glob';
 import type { PluginOption } from 'vite';
 
-export const watchPublicPlugin = (): PluginOption => {
-  return {
-    name: 'watch-public-plugin',
-    async buildStart() {
-      const files = await fg(['public/**/*']);
+export const watchPublicPlugin = (): PluginOption => ({
+  name: 'watch-public-plugin',
+  async buildStart() {
+    const files = await fg(['public/**/*']);
 
-      for (const file of files) {
-        this.addWatchFile(file);
-      }
-    },
-  };
-};
+    for (const file of files) {
+      this.addWatchFile(file);
+    }
+  },
+});

--- a/packages/shared/lib/hoc/withErrorBoundary.tsx
+++ b/packages/shared/lib/hoc/withErrorBoundary.tsx
@@ -5,12 +5,11 @@ import type { FallbackProps } from 'react-error-boundary';
 export const withErrorBoundary = <T extends Record<string, unknown>>(
   Component: ComponentType<T>,
   FallbackComponent: ComponentType<FallbackProps>,
-) => {
-  return function WithErrorBoundary(props: T) {
+) =>
+  function WithErrorBoundary(props: T) {
     return (
       <ErrorBoundary FallbackComponent={FallbackComponent}>
         <Component {...props} />
       </ErrorBoundary>
     );
   };
-};

--- a/packages/shared/lib/hoc/withSuspense.tsx
+++ b/packages/shared/lib/hoc/withSuspense.tsx
@@ -1,15 +1,10 @@
 import { Suspense } from 'react';
 import type { ComponentType, ReactElement } from 'react';
 
-export const withSuspense = <T extends Record<string, unknown>>(
-  Component: ComponentType<T>,
-  SuspenseComponent: ReactElement,
-) => {
-  return (props: T) => {
-    return (
-      <Suspense fallback={SuspenseComponent}>
-        <Component {...props} />
-      </Suspense>
-    );
-  };
-};
+export const withSuspense =
+  <T extends Record<string, unknown>>(Component: ComponentType<T>, SuspenseComponent: ReactElement) =>
+  (props: T) => (
+    <Suspense fallback={SuspenseComponent}>
+      <Component {...props} />
+    </Suspense>
+  );

--- a/packages/storage/lib/base/base.ts
+++ b/packages/storage/lib/base/base.ts
@@ -3,7 +3,7 @@ import type { BaseStorage, StorageConfig, ValueOrUpdate } from '../types.js';
 
 /**
  * Chrome reference error while running `processTailwindFeatures` in tailwindcss.
- *  To avoid this, we need to check if the globalThis.chrome is available and add fallback logic.
+ *  To avoid this, we need to check if globalThis.chrome is available and add fallback logic.
  */
 const chrome = globalThis.chrome;
 
@@ -12,16 +12,12 @@ const chrome = globalThis.chrome;
  */
 const updateCache = async <D>(valueOrUpdate: ValueOrUpdate<D>, cache: D | null): Promise<D> => {
   // Type guard to check if our value or update is a function
-  const isFunction = <D>(value: ValueOrUpdate<D>): value is (prev: D) => D | Promise<D> => {
-    return typeof value === 'function';
-  };
+  const isFunction = <D>(value: ValueOrUpdate<D>): value is (prev: D) => D | Promise<D> => typeof value === 'function';
 
-  // Type guard to check in case of a function, if its a Promise
-  const returnsPromise = <D>(func: (prev: D) => D | Promise<D>): func is (prev: D) => Promise<D> => {
+  // Type guard to check in case of a function if it's a Promise
+  const returnsPromise = <D>(func: (prev: D) => D | Promise<D>): func is (prev: D) => Promise<D> =>
     // Use ReturnType to infer the return type of the function and check if it's a Promise
-    return (func as (prev: D) => Promise<D>) instanceof Promise;
-  };
-
+    (func as (prev: D) => Promise<D>) instanceof Promise;
   if (isFunction(valueOrUpdate)) {
     // Check if the function returns a Promise
     if (returnsPromise(valueOrUpdate)) {
@@ -116,9 +112,7 @@ export const createStorage = <D = string>(key: string, fallback: D, config?: Sto
     };
   };
 
-  const getSnapshot = () => {
-    return cache;
-  };
+  const getSnapshot = () => cache;
 
   const _emitChange = () => {
     listeners.forEach(listener => listener());

--- a/packages/ui/lib/utils.ts
+++ b/packages/ui/lib/utils.ts
@@ -2,6 +2,4 @@ import { clsx } from 'clsx';
 import { twMerge } from 'tailwind-merge';
 import type { ClassValue } from 'clsx';
 
-export const cn = (...inputs: ClassValue[]) => {
-  return twMerge(clsx(inputs));
-};
+export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));

--- a/packages/ui/lib/withUI.ts
+++ b/packages/ui/lib/withUI.ts
@@ -1,8 +1,7 @@
 import deepmerge from 'deepmerge';
 import type { Config } from 'tailwindcss';
 
-export const withUI = (tailwindConfig: Config): Config => {
-  return deepmerge(tailwindConfig, {
+export const withUI = (tailwindConfig: Config): Config =>
+  deepmerge(tailwindConfig, {
     content: ['../../packages/ui/lib/**/*.tsx'],
   });
-};

--- a/packages/zipper/lib/index.ts
+++ b/packages/zipper/lib/index.ts
@@ -5,9 +5,7 @@ import { createWriteStream, existsSync, mkdirSync } from 'node:fs';
 import { posix, resolve } from 'node:path';
 
 // Converts bytes to megabytes
-const toMB = (bytes: number): number => {
-  return bytes / 1024 / 1024;
-};
+const toMB = (bytes: number): number => bytes / 1024 / 1024;
 
 // Creates the build directory if it doesn't exist
 const ensureBuildDirectoryExists = (buildDirectory: string): void => {


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to simplify func by defining eslint rule, for checking unnecessary `return` statements

## Changes*
Added `'arrow-body-style': ['error', 'as-needed'],` to `eslint.config.ts`

## How to check the feature
Run `pnpm lint` and check if there aren't errors