### PR TITLE
fix: adjust env package to look like other packages

### DIFF
--- a/packages/env/index.mts
+++ b/packages/env/index.mts
@@ -1,12 +1,9 @@
 import { baseEnv, dynamicEnvValues } from './lib/index.js';
 import type { IEnv } from './lib/types.js';
 
-export * from './lib/const.js';
 export * from './lib/index.js';
 
-const env = {
+export default {
   ...baseEnv,
   ...dynamicEnvValues,
 } as IEnv;
-
-export default env;

--- a/packages/env/lib/config.ts
+++ b/packages/env/lib/config.ts
@@ -1,0 +1,10 @@
+import { config } from '@dotenvx/dotenvx';
+
+export const baseEnv =
+  config({
+    path: `${import.meta.dirname}/../../../../.env`,
+  }).parsed ?? {};
+
+export const dynamicEnvValues = {
+  CEB_NODE_ENV: baseEnv.CEB_DEV === 'true' ? 'development' : 'production',
+} as const;

--- a/packages/env/lib/index.ts
+++ b/packages/env/lib/index.ts
@@ -1,10 +1,2 @@
-import { config } from '@dotenvx/dotenvx';
-
-export const baseEnv =
-  config({
-    path: `${import.meta.dirname}/../../../../.env`,
-  }).parsed ?? {};
-
-export const dynamicEnvValues = {
-  CEB_NODE_ENV: baseEnv.CEB_DEV === 'true' ? 'development' : 'production',
-} as const;
+export * from './config.js';
+export * from './const.js';


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to adjust `env` package to export everything necessary from `lib/index.ts` like other packages

## Changes*
I've created `config.ts` for content of previous `index.ts` and export it in current `index.ts`