### PR TITLE
feat/add-removing-tests-to-module-manager

### DIFF
--- a/packages/module-manager/README.md
+++ b/packages/module-manager/README.md
@@ -28,9 +28,13 @@ OR
 pnpm start -d popup
 ```
 
-> [!INFO]  
+> [!NOTE]  
 > For complete info about CLI support run:
 > ```bash pnpm module-manager --help ```
+
+> [!IMPORTANT]
+> If you want to remove all tests, and something else with one command, you need to set `tests` as first argument like:
+> ```bash pnpm module-manager -d tests popup ...```
 
 ### Choose a tool
 

--- a/packages/module-manager/README.md
+++ b/packages/module-manager/README.md
@@ -30,11 +30,11 @@ pnpm start -d popup
 
 > [!NOTE]  
 > For complete info about CLI support run:
-> ```bash pnpm module-manager --help ```
+> `pnpm module-manager --help`
 
 > [!IMPORTANT]
 > If you want to remove all tests, and something else with one command, you need to set `tests` as first argument like:
-> ```bash pnpm module-manager -d tests popup ...```
+> `pnpm module-manager -d tests popup ...`
 
 ### Choose a tool
 

--- a/packages/module-manager/index.mts
+++ b/packages/module-manager/index.mts
@@ -1,15 +1,18 @@
-import { colorfulLog } from '@extension/shared';
+import { colorfulLog, sleep } from '@extension/shared';
 import { processCLIArgs, runModuleManager } from './lib/index.js';
 
 const cliOptions = processCLIArgs();
 
 if (cliOptions) {
   const targets = cliOptions.targets;
-  for (const moduleName of targets) {
-    colorfulLog(`Processing module: ${moduleName}`, 'info');
-    const isLastIndex = targets.at(-1) === moduleName;
-    void runModuleManager(moduleName, cliOptions.action, isLastIndex);
-  }
+  (async () => {
+    for (const moduleName of targets) {
+      colorfulLog(`Processing module: ${moduleName}`, 'info');
+      const isLastIndex = targets.at(-1) === moduleName;
+      await runModuleManager(moduleName, cliOptions.action, isLastIndex);
+      await sleep(500);
+    }
+  })();
 } else {
   void runModuleManager();
 }

--- a/packages/module-manager/lib/const.ts
+++ b/packages/module-manager/lib/const.ts
@@ -12,6 +12,7 @@ export const DEFAULT_CHOICES = [
   { name: 'DevTools (Include DevTools Panel)', value: 'devtools' },
   { name: 'Side Panel', value: 'side-panel' },
   { name: 'Options Page', value: 'options' },
+  { name: 'All tests', value: 'tests' },
 ] as const;
 
 export const DEFAULT_CHOICES_VALUES = DEFAULT_CHOICES.map(item => item.value);

--- a/packages/module-manager/lib/delete-feature.ts
+++ b/packages/module-manager/lib/delete-feature.ts
@@ -30,8 +30,8 @@ export const deleteFeature = async (manifestObject: ManifestType, moduleName?: M
 
   if (moduleName === 'devtools') {
     await deleteModule(manifestObject, moduleName as ModuleNameType, false);
-    await deleteModule(manifestObject, 'devtools-panel');
+    await deleteModule(manifestObject, 'devtools-panel', existsSync(testsPath));
   } else {
-    await deleteModule(manifestObject, moduleName as ModuleNameType);
+    await deleteModule(manifestObject, moduleName as ModuleNameType, existsSync(testsPath));
   }
 };

--- a/packages/module-manager/lib/delete-feature.ts
+++ b/packages/module-manager/lib/delete-feature.ts
@@ -1,30 +1,31 @@
 import { DEFAULT_CHOICES, DELETE_CHOICE_QUESTION } from './const.js';
 import { deleteModule } from './modules-handler.js';
-import { promptSelection } from './utils.js';
-import { readdirSync } from 'node:fs';
+import { processSelection } from './utils.js';
+import { existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { ChoiceType, ModuleNameType } from './types.ts';
+import type { ChoicesType, ModuleNameType } from './types.ts';
 import type { ManifestType } from '@extension/shared';
 
 const pagesPath = resolve(import.meta.dirname, '..', '..', '..', 'pages');
+const testsPath = resolve(pagesPath, '..', 'tests');
 
 const pageFolders = readdirSync(pagesPath);
 
 export const deleteFeature = async (manifestObject: ManifestType, moduleName?: ModuleNameType) => {
-  if (!moduleName) {
-    const choices: ChoiceType[] = DEFAULT_CHOICES.filter(choice => {
-      if (choice.value === 'background') {
-        return !!manifestObject.background;
-      }
-      return pageFolders.includes(choice.value);
-    });
+  const choices: ChoicesType = DEFAULT_CHOICES.filter(choice => {
+    if (choice.value === 'background') {
+      return !!manifestObject.background;
+    } else if (choice.value === 'tests') {
+      return existsSync(testsPath);
+    }
 
-    const inputConfig = {
-      message: DELETE_CHOICE_QUESTION,
-      choices,
-    } as const;
+    return pageFolders.includes(choice.value);
+  });
 
-    moduleName = (await promptSelection(inputConfig)) as Awaited<ModuleNameType>;
+  const processResult = await processSelection(choices, DELETE_CHOICE_QUESTION, moduleName);
+
+  if (processResult) {
+    moduleName = processResult;
   }
 
   if (moduleName === 'devtools') {

--- a/packages/module-manager/lib/modules-handler.ts
+++ b/packages/module-manager/lib/modules-handler.ts
@@ -11,7 +11,7 @@ const testsPath = resolve(pagesPath, '..', 'tests');
 const specsPath = resolve(testsPath, 'e2e', 'specs');
 const archivePath = resolve(import.meta.dirname, '..', 'archive');
 
-export const recoverModule = (manifestObject: ManifestType, moduleName: ModuleNameType, withTest = true) => {
+export const recoverModule = (manifestObject: ManifestType, moduleName: ModuleNameType, withTest: boolean) => {
   const zipFilePath = resolve(archivePath, `${moduleName}.zip`);
   const zipTestFilePath = resolve(archivePath, `${moduleName}.test.zip`);
 
@@ -35,7 +35,7 @@ export const recoverModule = (manifestObject: ManifestType, moduleName: ModuleNa
   }
 };
 
-export const deleteModule = async (manifestObject: ManifestType, moduleName: ModuleNameType, withTest = true) => {
+export const deleteModule = async (manifestObject: ManifestType, moduleName: ModuleNameType, withTest: boolean) => {
   processModuleConfig(manifestObject, moduleName);
 
   if (!existsSync(archivePath)) {

--- a/packages/module-manager/lib/modules-handler.ts
+++ b/packages/module-manager/lib/modules-handler.ts
@@ -1,5 +1,5 @@
 import { isFolderEmpty, processModuleConfig } from './utils.js';
-import { unZipAndDeleteModule, zipAndDeleteModule } from './zip-utils.js';
+import { unZipAndDeleteModule, zipAndDeleteModule, zipAndDeleteTests } from './zip-utils.js';
 import { colorfulLog } from '@extension/shared';
 import { existsSync, mkdirSync, rmdirSync } from 'node:fs';
 import { resolve } from 'node:path';
@@ -7,7 +7,8 @@ import type { ModuleNameType } from './types.ts';
 import type { ManifestType } from '@extension/shared';
 
 const pagesPath = resolve(import.meta.dirname, '..', '..', '..', 'pages');
-const testsPath = resolve(pagesPath, '..', 'tests', 'e2e', 'specs');
+const testsPath = resolve(pagesPath, '..', 'tests');
+const specsPath = resolve(testsPath, 'e2e', 'specs');
 const archivePath = resolve(import.meta.dirname, '..', 'archive');
 
 export const recoverModule = (manifestObject: ManifestType, moduleName: ModuleNameType, withTest = true) => {
@@ -24,7 +25,7 @@ export const recoverModule = (manifestObject: ManifestType, moduleName: ModuleNa
   unZipAndDeleteModule(zipFilePath, pagesPath);
 
   if (withTest) {
-    unZipAndDeleteModule(zipTestFilePath, testsPath);
+    unZipAndDeleteModule(zipTestFilePath, specsPath);
   }
 
   colorfulLog(`Recovered: ${moduleName}`, 'info');
@@ -41,8 +42,10 @@ export const deleteModule = async (manifestObject: ManifestType, moduleName: Mod
     mkdirSync(archivePath, { recursive: true });
   }
 
-  if (withTest) {
-    await zipAndDeleteModule(moduleName, pagesPath, archivePath, testsPath);
+  if (moduleName === 'tests') {
+    await zipAndDeleteTests(testsPath, archivePath);
+  } else if (withTest) {
+    await zipAndDeleteModule(moduleName, pagesPath, archivePath, specsPath);
   } else {
     await zipAndDeleteModule(moduleName, pagesPath, archivePath);
   }

--- a/packages/module-manager/lib/recover-feature.ts
+++ b/packages/module-manager/lib/recover-feature.ts
@@ -1,33 +1,42 @@
 import { DEFAULT_CHOICES, RECOVER_CHOICE_QUESTION } from './const.js';
 import { recoverModule } from './modules-handler.js';
-import { promptSelection } from './utils.js';
+import { processSelection } from './utils.js';
+import { rimraf } from 'rimraf';
 import { existsSync, readdirSync } from 'node:fs';
 import { resolve } from 'node:path';
-import type { ChoiceType, ModuleNameType } from './types.ts';
+import type { ChoicesType, ModuleNameType } from './types.ts';
 import type { ManifestType } from '@extension/shared';
 
 const archivePath = resolve(import.meta.dirname, '..', 'archive');
+const testsPath = resolve(import.meta.dirname, '..', '..', '..', 'tests');
 
 const archiveFiles = existsSync(archivePath) ? readdirSync(archivePath) : [];
 
 export const recoverFeature = async (manifestObject: ManifestType, moduleName?: ModuleNameType) => {
-  if (!moduleName) {
-    const choices: ChoiceType[] = DEFAULT_CHOICES.filter(choice => {
-      if (choice.value === 'background') {
-        return !manifestObject.background;
-      }
-      return archiveFiles.includes(`${choice.value}.zip`);
-    });
+  const choices: ChoicesType = DEFAULT_CHOICES.filter(choice => {
+    if (choice.value === 'background') {
+      return !manifestObject.background;
+    } else if (choice.value === 'tests') {
+      return !existsSync(testsPath);
+    }
 
-    const inputConfig = {
-      message: RECOVER_CHOICE_QUESTION,
-      choices,
-    } as const;
+    return archiveFiles.includes(`${choice.value}.zip`);
+  });
 
-    moduleName = (await promptSelection(inputConfig)) as Awaited<ModuleNameType>;
+  const processResult = await processSelection(choices, RECOVER_CHOICE_QUESTION, moduleName);
+
+  if (processResult) {
+    moduleName = processResult;
   }
 
-  if (moduleName === 'devtools') {
+  if (moduleName === 'tests' || !existsSync(testsPath)) {
+    recoverModule(manifestObject, moduleName as ModuleNameType, false);
+    const testZipFilePath = resolve(archivePath, `${moduleName}.test.zip`);
+
+    if (existsSync(testZipFilePath)) {
+      await rimraf(testZipFilePath);
+    }
+  } else if (moduleName === 'devtools') {
     recoverModule(manifestObject, moduleName as ModuleNameType, false);
     recoverModule(manifestObject, 'devtools-panel');
   } else {

--- a/packages/module-manager/lib/recover-feature.ts
+++ b/packages/module-manager/lib/recover-feature.ts
@@ -38,8 +38,8 @@ export const recoverFeature = async (manifestObject: ManifestType, moduleName?: 
     }
   } else if (moduleName === 'devtools') {
     recoverModule(manifestObject, moduleName as ModuleNameType, false);
-    recoverModule(manifestObject, 'devtools-panel');
+    recoverModule(manifestObject, 'devtools-panel', existsSync(testsPath));
   } else {
-    recoverModule(manifestObject, moduleName as ModuleNameType);
+    recoverModule(manifestObject, moduleName as ModuleNameType, existsSync(testsPath));
   }
 };

--- a/packages/module-manager/lib/run-module-manager.ts
+++ b/packages/module-manager/lib/run-module-manager.ts
@@ -14,7 +14,7 @@ const manifestPath = resolve(import.meta.dirname, '..', '..', '..', 'chrome-exte
 const manifestObject = JSON.parse(JSON.stringify(manifest)) as ManifestType;
 const manifestString = readFileSync(manifestPath, 'utf-8');
 
-export const runModuleManager = async (moduleName?: ModuleNameType, action?: CliActionType, runLinter = true) => {
+export const runModuleManager = async (moduleName?: ModuleNameType, action?: CliActionType, isLastLap = true) => {
   if (!action) {
     action = (await promptSelection(MANAGER_ACTION_PROMPT_CONFIG)) as Awaited<CliActionType>;
   }
@@ -35,12 +35,13 @@ export const runModuleManager = async (moduleName?: ModuleNameType, action?: Cli
     .replace(/ {2}"version": "[\s\S]*?",/, '  version: packageJson.version,');
 
   writeFileSync(manifestPath, updatedManifest);
-  execSync('pnpm i', {
-    stdio: 'inherit',
-    cwd: resolve('..', '..'),
-  });
 
-  if (runLinter) {
+  if (isLastLap) {
+    execSync('pnpm i', {
+      stdio: 'inherit',
+      cwd: resolve('..', '..'),
+    });
+
     execSync('pnpm -F chrome-extension lint:fix', {
       stdio: 'inherit',
       cwd: resolve('..', '..'),

--- a/packages/module-manager/lib/types.ts
+++ b/packages/module-manager/lib/types.ts
@@ -5,6 +5,7 @@ import type { select } from '@inquirer/prompts';
 type ModuleConfigType = typeof MODULE_CONFIG;
 
 export type ChoiceType = (typeof DEFAULT_CHOICES)[number];
+export type ChoicesType = (typeof DEFAULT_CHOICES)[number][];
 export type ModuleNameType = ChoiceType['value'] | 'devtools-panel';
 export type InputConfigType = Parameters<typeof select>[0];
 export type WritableModuleConfigValuesType<T extends keyof ModuleConfigType> = WritableDeep<ModuleConfigType[T]>;

--- a/packages/module-manager/lib/zip-utils.ts
+++ b/packages/module-manager/lib/zip-utils.ts
@@ -30,6 +30,11 @@ export const zipAndDeleteModule = async (
   }
 };
 
+export const zipAndDeleteTests = async (testsPath: string, archivePath: string) => {
+  await zipFolder(testsPath, resolve(archivePath, `tests.zip`));
+  void rimraf(testsPath);
+};
+
 export const unZipAndDeleteModule = (zipFilePath: string, destPath: string) => {
   const unzipped = unzipSync(readFileSync(zipFilePath));
 
@@ -46,10 +51,15 @@ export const unZipAndDeleteModule = (zipFilePath: string, destPath: string) => {
 };
 
 export const zipFolder = async (folderPath: string, out: string, filesToInclude?: string[]) => {
-  const fileList = await fg(['!node_modules', '!dist'].concat(filesToInclude?.length ? filesToInclude : ['**/*']), {
-    cwd: folderPath,
-    onlyFiles: true,
-  });
+  const fileList = await fg(
+    ['!node_modules', '!dist', '!**/*/node_modules', '!**/*/dist'].concat(
+      filesToInclude?.length ? filesToInclude : ['**/*'],
+    ),
+    {
+      cwd: folderPath,
+      onlyFiles: true,
+    },
+  );
   const output = createWriteStream(out);
 
   return new Promise<void>((resolvePromise, rejectPromise) => {

--- a/packages/shared/lib/utils/helpers.ts
+++ b/packages/shared/lib/utils/helpers.ts
@@ -4,3 +4,5 @@ export const excludeValuesFromBaseArray = <B extends string[], E extends (string
   baseArray: B,
   excludeArray: E,
 ) => baseArray.filter(value => !excludeArray.includes(value)) as TExcludeValuesFromBaseArray<B, E>;
+
+export const sleep = async (time: number) => new Promise(r => setTimeout(r, time));


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to add support for removing tests with `module-manager`

## Changes*
Added `tests` options for terminal select
Added CLI support for removing tests with other modules

## How to check the feature
Run `pnpm module-manager` or `pnpm module-manager -d tests popup` and check if it works