### PR TITLE
feat: enable daemon for turbo.json

### DIFF
--- a/turbo.json
+++ b/turbo.json
@@ -4,7 +4,6 @@
   "globalEnv": ["CEB_*", "CLI_CEB_*"],
   "globalDependencies": [".env"],
   "concurrency": "12",
-  "daemon": false,
   "tasks": {
     "ready": {
       "dependsOn": ["^ready"],


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to enable daemon again, because it seems `turborepo` fixed issue with daemon and this fixes #827

## Changes*
I've removed `daemon` option from `turbo.json` to use default