### PR TITLE
feat/enable-prettier-tailwind-plugin

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -5,5 +5,8 @@
   "arrowParens": "avoid",
   "printWidth": 120,
   "bracketSameLine": true,
-  "htmlWhitespaceSensitivity": "strict"
+  "htmlWhitespaceSensitivity": "strict",
+  "plugins": [
+    "prettier-plugin-tailwindcss"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "postcss": "^8.5.3",
     "postcss-load-config": "^6.0.1",
     "prettier": "^3.5.3",
+    "prettier-plugin-tailwindcss": "^0.6.11",
     "rimraf": "^6.0.1",
     "run-script-os": "^1.1.6",
     "tailwindcss": "^3.4.17",

--- a/packages/ui/global.css
+++ b/packages/ui/global.css
@@ -3,17 +3,18 @@
 @tailwind utilities;
 
 body {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  box-sizing: border-box;
 
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans',
-    'Droid Sans', 'Helvetica Neue', sans-serif;
+  font-family:
+    -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
+    'Helvetica Neue', sans-serif;
 
-    -webkit-font-smoothing: antialiased;
-    -moz-osx-font-smoothing: grayscale;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
 }
 
 code {
-    font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
+  font-family: source-code-pro, Menlo, Monaco, Consolas, 'Courier New', monospace;
 }

--- a/packages/ui/lib/components/LoadingSpinner.tsx
+++ b/packages/ui/lib/components/LoadingSpinner.tsx
@@ -5,7 +5,7 @@ interface ILoadingSpinnerProps {
 }
 
 export const LoadingSpinner = ({ size }: ILoadingSpinnerProps) => (
-  <div className={'flex justify-center items-center min-h-screen'}>
+  <div className={'flex min-h-screen items-center justify-center'}>
     <RingLoader size={size ?? 100} color={'aqua'} />
   </div>
 );

--- a/packages/ui/lib/components/ToggleButton.tsx
+++ b/packages/ui/lib/components/ToggleButton.tsx
@@ -11,8 +11,8 @@ export const ToggleButton = ({ className, children, ...props }: ToggleButtonProp
   return (
     <button
       className={cn(
-        'py-1 px-4 rounded shadow hover:scale-105 mt-4 border-2 font-bold',
-        isLight ? 'bg-white border-black text-black' : 'bg-black text-white border-white',
+        'mt-4 rounded border-2 px-4 py-1 font-bold shadow hover:scale-105',
+        isLight ? 'border-black bg-white text-black' : 'border-white bg-black text-white',
         className,
       )}
       onClick={exampleThemeStorage.toggle}

--- a/packages/ui/lib/components/error-display/ErrorDisplay.tsx
+++ b/packages/ui/lib/components/error-display/ErrorDisplay.tsx
@@ -3,8 +3,8 @@ import { ErrorResetButton } from '@/lib/components/error-display/ErrorResetButto
 import { ErrorStackTraceList } from '@/lib/components/error-display/ErrorStackTraceList';
 
 export const ErrorDisplay = ({ error, resetErrorBoundary }: { error?: Error; resetErrorBoundary?: () => void }) => (
-  <div className="flex items-center justify-center bg-gray-50 py-6 px-4 sm:px-6 lg:px-8">
-    <div className="max-w-md w-full space-y-8">
+  <div className="flex items-center justify-center bg-gray-50 px-4 py-6 sm:px-6 lg:px-8">
+    <div className="w-full max-w-md space-y-8">
       <ErrorHeader />
       <ErrorStackTraceList error={error} />
       <ErrorResetButton resetErrorBoundary={resetErrorBoundary} />

--- a/packages/ui/lib/components/error-display/ErrorResetButton.tsx
+++ b/packages/ui/lib/components/error-display/ErrorResetButton.tsx
@@ -4,7 +4,7 @@ export const ErrorResetButton = ({ resetErrorBoundary }: { resetErrorBoundary?: 
   <div className="flex items-center justify-center">
     <button
       onClick={resetErrorBoundary}
-      className="inline-flex items-center px-4 py-2 border border-transparent text-sm font-medium rounded-md shadow-sm text-white bg-red-600 hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-red-500">
+      className="inline-flex items-center rounded-md border border-transparent bg-red-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2">
       {t('displayErrorReset')}
     </button>
   </div>

--- a/packages/ui/lib/components/error-display/ErrorStackTraceList.tsx
+++ b/packages/ui/lib/components/error-display/ErrorStackTraceList.tsx
@@ -1,16 +1,16 @@
 import { t } from '@extension/i18n';
 
 export const ErrorStackTraceList = ({ error }: { error?: Error }) => (
-  <div className="bg-white shadow overflow-hidden rounded-lg">
+  <div className="overflow-hidden rounded-lg bg-white shadow">
     <div className="px-4 py-5 sm:p-6">
       <div className="text-sm text-gray-500">
-        <p className="font-medium text-gray-700 mb-2">{t('displayErrorDetailsInfo')}</p>
-        <div className="bg-red-50 p-4 rounded-md overflow-auto">
-          <p className="text-red-700 font-mono break-all">{error?.message || t('displayErrorUnknownErrorInfo')}</p>
+        <p className="mb-2 font-medium text-gray-700">{t('displayErrorDetailsInfo')}</p>
+        <div className="overflow-auto rounded-md bg-red-50 p-4">
+          <p className="break-all font-mono text-red-700">{error?.message || t('displayErrorUnknownErrorInfo')}</p>
           {error?.stack && (
             <details className="mt-3">
-              <summary className="text-sm text-red-700 cursor-pointer">Stack trace</summary>
-              <pre className="mt-2 text-xs text-red-800 overflow-auto p-2">{error?.stack}</pre>
+              <summary className="cursor-pointer text-sm text-red-700">Stack trace</summary>
+              <pre className="mt-2 overflow-auto p-2 text-xs text-red-800">{error?.stack}</pre>
             </details>
           )}
         </div>

--- a/pages/content-runtime/src/matches/all/index.css
+++ b/pages/content-runtime/src/matches/all/index.css
@@ -1,5 +1,5 @@
 @import '@extension/ui/global.css';
 
 .ceb-all-runtime-content-view-text {
-    font-size: 20px;
+  font-size: 20px;
 }

--- a/pages/content-runtime/src/matches/example/index.css
+++ b/pages/content-runtime/src/matches/example/index.css
@@ -1,5 +1,5 @@
 @import '@extension/ui/global.css';
 
 .ceb-example-runtime-content-view-text {
-    font-size: 20px;
+  font-size: 20px;
 }

--- a/pages/content-ui/src/matches/all/App.tsx
+++ b/pages/content-ui/src/matches/all/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
 
   return (
     <div className="flex items-center justify-between gap-2 rounded bg-blue-100 px-2 py-1">
-      <div className="flex gap-1 text-blue-500 text-sm">
+      <div className="flex gap-1 text-sm text-blue-500">
         Edit <strong className="text-blue-700">pages/content-ui/src/matches/all/App.tsx</strong> and save to reload.
       </div>
       <ToggleButton className={'mt-0'}>{t('toggleTheme')}</ToggleButton>

--- a/pages/content-ui/src/matches/example/App.tsx
+++ b/pages/content-ui/src/matches/example/App.tsx
@@ -9,7 +9,7 @@ export default function App() {
 
   return (
     <div className="flex items-center justify-between gap-2 rounded bg-blue-100 px-2 py-1">
-      <div className="flex gap-1 text-blue-500 text-xs">
+      <div className="flex gap-1 text-xs text-blue-500">
         Edit <strong className="text-blue-700">pages/content-ui/src/matches/example/App.tsx</strong> and save to reload.
       </div>
       <ToggleButton className={'mt-0'}>{t('toggleTheme')}</ToggleButton>

--- a/pages/devtools-panel/src/Panel.tsx
+++ b/pages/devtools-panel/src/Panel.tsx
@@ -33,7 +33,7 @@ const ToggleButton = (props: ComponentPropsWithoutRef<'button'>) => {
     <button
       className={cn(
         props.className,
-        'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105 ',
+        'mt-4 rounded px-4 py-1 font-bold shadow hover:scale-105',
         isLight ? 'bg-white text-black' : 'bg-black text-white',
       )}
       onClick={exampleThemeStorage.toggle}>

--- a/pages/popup/src/Popup.tsx
+++ b/pages/popup/src/Popup.tsx
@@ -48,7 +48,7 @@ const Popup = () => {
         </p>
         <button
           className={cn(
-            'font-bold mt-4 py-1 px-4 rounded shadow hover:scale-105',
+            'mt-4 rounded px-4 py-1 font-bold shadow hover:scale-105',
             isLight ? 'bg-blue-200 text-black' : 'bg-gray-700 text-white',
           )}
           onClick={injectContentScript}>

--- a/pages/popup/src/index.css
+++ b/pages/popup/src/index.css
@@ -1,6 +1,6 @@
 @import '@extension/ui/global.css';
 
 body {
-    width: 300px;
-    height: 260px;
+  width: 300px;
+  height: 260px;
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       prettier:
         specifier: ^3.5.3
         version: 3.5.3
+      prettier-plugin-tailwindcss:
+        specifier: ^0.6.11
+        version: 0.6.11(prettier@3.5.3)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1
@@ -4033,6 +4036,61 @@ packages:
   prettier-linter-helpers@1.0.0:
     resolution: {integrity: sha512-GbK2cP9nraSSUF9N2XwUwqfzlAFlMNYYl+ShE/V+H8a9uNl/oUqB1w2EL54Jh0OlyRSd8RfWYJ3coVS4TROP2w==}
     engines: {node: '>=6.0.0'}
+
+  prettier-plugin-tailwindcss@0.6.11:
+    resolution: {integrity: sha512-YxaYSIvZPAqhrrEpRtonnrXdghZg1irNg4qrjboCXrpybLWVs55cW2N3juhspVJiO0JBvYJT8SYsJpc8OQSnsA==}
+    engines: {node: '>=14.21.3'}
+    peerDependencies:
+      '@ianvs/prettier-plugin-sort-imports': '*'
+      '@prettier/plugin-pug': '*'
+      '@shopify/prettier-plugin-liquid': '*'
+      '@trivago/prettier-plugin-sort-imports': '*'
+      '@zackad/prettier-plugin-twig': '*'
+      prettier: ^3.0
+      prettier-plugin-astro: '*'
+      prettier-plugin-css-order: '*'
+      prettier-plugin-import-sort: '*'
+      prettier-plugin-jsdoc: '*'
+      prettier-plugin-marko: '*'
+      prettier-plugin-multiline-arrays: '*'
+      prettier-plugin-organize-attributes: '*'
+      prettier-plugin-organize-imports: '*'
+      prettier-plugin-sort-imports: '*'
+      prettier-plugin-style-order: '*'
+      prettier-plugin-svelte: '*'
+    peerDependenciesMeta:
+      '@ianvs/prettier-plugin-sort-imports':
+        optional: true
+      '@prettier/plugin-pug':
+        optional: true
+      '@shopify/prettier-plugin-liquid':
+        optional: true
+      '@trivago/prettier-plugin-sort-imports':
+        optional: true
+      '@zackad/prettier-plugin-twig':
+        optional: true
+      prettier-plugin-astro:
+        optional: true
+      prettier-plugin-css-order:
+        optional: true
+      prettier-plugin-import-sort:
+        optional: true
+      prettier-plugin-jsdoc:
+        optional: true
+      prettier-plugin-marko:
+        optional: true
+      prettier-plugin-multiline-arrays:
+        optional: true
+      prettier-plugin-organize-attributes:
+        optional: true
+      prettier-plugin-organize-imports:
+        optional: true
+      prettier-plugin-sort-imports:
+        optional: true
+      prettier-plugin-style-order:
+        optional: true
+      prettier-plugin-svelte:
+        optional: true
 
   prettier@3.5.3:
     resolution: {integrity: sha512-QQtaxnoDJeAkDvDKWCLiwIXkTgRhwYDEQCghU9Z6q03iyek/rxRh/2lC3HB7P8sWT2xC/y5JDctPLBIGzHKbhw==}
@@ -8879,6 +8937,10 @@ snapshots:
   prettier-linter-helpers@1.0.0:
     dependencies:
       fast-diff: 1.3.0
+
+  prettier-plugin-tailwindcss@0.6.11(prettier@3.5.3):
+    dependencies:
+      prettier: 3.5.3
 
   prettier@3.5.3: {}
 


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to enable `prettier-tailwind-plugin` for entire project, to have consist classNames formating

## Changes*
Installed `prettier-tailwind-plugin` and enable it on `.prettierrc` 

## How to check the feature
Run `pnpm format` and check if it works(shouldn't format anything, should be valid)