### PR TITLE
fix: start init-reload-server directly from .ts file

### DIFF
--- a/packages/hmr/package.json
+++ b/packages/hmr/package.json
@@ -16,7 +16,7 @@
     "clean:turbo": "rimraf .turbo",
     "clean": "pnpm clean:bundle && pnpm clean:node_modules && pnpm clean:turbo",
     "ready": "tsc -b && rollup --config dist/rollup.config.js",
-    "dev": "node dist/lib/initializers/init-reload-server.js",
+    "dev": "tsx lib/initializers/init-reload-server.ts",
     "lint": "eslint .",
     "lint:fix": "pnpm lint --fix",
     "format": "prettier . --write --ignore-path ../../.prettierignore",


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to fix issue with starting reload server

## Changes*
I've changed entry point from /dist to directly .ts file with `tsx`, because it wasn't starting well everytime with previous approach

## How to check the feature
Run `pnpm dev` and check if it works