### PR TITLE
fix: skip throwing error on init-reload-server.ts when server already running

### DIFF
--- a/packages/hmr/lib/initializers/init-reload-server.ts
+++ b/packages/hmr/lib/initializers/init-reload-server.ts
@@ -42,8 +42,12 @@ const clientsThatNeedToUpdate: Set<WebSocket> = new Set();
     });
   });
 
-  wss.on('error', error => {
-    console.error(`[HMR] Failed to start server at ${LOCAL_RELOAD_SOCKET_URL}`);
-    throw error;
+  wss.on('error', (error: Error & { code: string }) => {
+    if (error.code === 'EADDRINUSE') {
+      console.info(`[HMR] Server already running at ${LOCAL_RELOAD_SOCKET_URL}, skipping reload server initialization`);
+    } else {
+      console.error(`[HMR] Failed to start server at ${LOCAL_RELOAD_SOCKET_URL}`);
+      throw error;
+    }
   });
 })();


### PR DESCRIPTION
<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to not throw error when HMR trying to reload it self because of e.g `turbo.json` edit

## Changes*
I've added display info about already running server on EADDRINUSE error code for init-reload-server.ts

## How to check the feature
Run `pnpm dev` and try to edit `turbo.json` and check new info in console.