### PR TITLE
fix/git-guardian-ignoring

### DIFF
--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,2 +1,2 @@
 paths-ignore:
-  - "pnpm-lock.yaml"
+  - "../pnpm-lock.yaml"


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `dev` branch -->

<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [x] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to fix checking `pnpm-lock.yaml` by `GitGuardian`
Because it throwing false-positive error on that file.

## Changes*
I've changed ignore path for `secret_scanning.yaml` on `.github`

## How to check the feature
Try to open any PR