### PR TITLE
remove blank_issues_enabled from ISSUE_TEMPLATE config.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,4 +1,3 @@
-blank_issues_enabled: false
 contact_links:
   - name: GitHub Community Support
     url: https://github.com/Jonghakseo/chrome-extension-boilerplate-react-vite/discussions


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `dev` branch -->

<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [x] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [ ] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
I want to use default value, to be able to create blank issue for e.g task

## Changes*
Removed blank_issues_enabled from `.github/ISSUE_TEMPLATE/config.yml`

## How to check the feature
After merge to `main` let's try to open blank issue