### PR TITLE
fix: remove unused `magic-string` devDependency from chrome-extension

### DIFF
--- a/chrome-extension/package.json
+++ b/chrome-extension/package.json
@@ -30,7 +30,6 @@
     "@extension/tsconfig": "workspace:*",
     "@extension/vite-config": "workspace:*",
     "@laynezh/vite-plugin-lib-assets": "^1.1.0",
-    "magic-string": "^0.30.17",
     "ts-loader": "^9.5.2"
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -169,9 +169,6 @@ importers:
       '@laynezh/vite-plugin-lib-assets':
         specifier: ^1.1.0
         version: 1.1.0(vite@6.3.5(@types/node@22.15.21)(jiti@2.4.2)(sass@1.89.0)(terser@5.39.2)(tsx@4.19.4)(yaml@2.8.0))
-      magic-string:
-        specifier: ^0.30.17
-        version: 0.30.17
       ts-loader:
         specifier: ^9.5.2
         version: 9.5.2(typescript@5.8.3)(webpack@5.94.0(@swc/core@1.11.24))
@@ -5706,7 +5703,6 @@ snapshots:
       '@types/react': 19.1.5
 
   '@types/react@19.1.5':
-
     dependencies:
       csstype: 3.1.3
 


### PR DESCRIPTION
<!-- Note: Please ensure your PR is targeting the `dev` branch -->

<!-- Describe what this PR is for in the title. -->

> `*` denotes required fields

## Priority*

- [ ] High: This PR needs to be merged first, before other tasks.
- [ ] Medium: This PR should be merged quickly to prevent conflicts due to common changes. (default)
- [x] Low: This PR does not affect other tasks, so it can be merged later.

## Purpose of the PR*
<!-- Describe the purpose of the PR. -->
As suggested in [Discord](https://discord.com/channels/1263404974830915637/1264514832917598228/1390738435819704432) earlier, this PR removes unused `magic-string` `devDependency` from chrome-extension's `package.json`.

## Changes*
This PR contains no functional changes to the codebase.
- Removes `magic-string` from `devDependencies` from `chrome-extension/package.json`

## How to check the feature
<!-- Describe how to check the feature in detail -->
<!-- If there are any visual changes, please attach a screenshot for easy identification. -->

## Reference
<!-- Any helpful information for understanding the PR. -->
- Code search result: https://github.com/search?q=repo%3AJonghakseo%2Fchrome-extension-boilerplate-react-vite%20magic-string&type=code